### PR TITLE
fix(desktop): preserve user message after reconnect

### DIFF
--- a/desktop/src/stores/chatStore.test.ts
+++ b/desktop/src/stores/chatStore.test.ts
@@ -7568,6 +7568,65 @@ describe('chatStore history mapping', () => {
     expect(sessionsApi.getMessages).toHaveBeenCalledTimes(2)
   })
 
+  it('preserves the current user message when reconnect history only contains the reply', async () => {
+    vi.mocked(sessionsApi.getMessages).mockClear()
+    vi.mocked(sessionsApi.getMessages).mockResolvedValue({
+      messages: [
+        {
+          id: 'persisted-assistant',
+          type: 'assistant',
+          timestamp: '2026-07-11T00:00:01.000Z',
+          content: [{ type: 'text', text: 'Hello! Is this message visible now?' }],
+        },
+      ],
+    })
+    useChatStore.setState({
+      sessions: {
+        [TEST_SESSION_ID]: makeSession({
+          chatState: 'streaming',
+          messages: [{
+            id: 'optimistic-user',
+            type: 'user_text',
+            content: 'Hello',
+            timestamp: Date.parse('2026-07-11T00:00:00.000Z'),
+          }],
+        }),
+      },
+    })
+
+    useChatStore.getState().handleServerMessage(TEST_SESSION_ID, {
+      type: 'session_state',
+      turnState: 'running',
+    })
+    await vi.waitFor(() => {
+      expect(sessionsApi.getMessages).toHaveBeenCalledTimes(1)
+    })
+
+    useChatStore.getState().handleServerMessage(TEST_SESSION_ID, {
+      type: 'thinking',
+      text: 'orphan reconnect thinking',
+    })
+    useChatStore.getState().handleServerMessage(TEST_SESSION_ID, {
+      type: 'content_delta',
+      text: 'Hello! Is this message visible now?',
+    })
+    useChatStore.getState().handleServerMessage(TEST_SESSION_ID, {
+      type: 'message_complete',
+      usage: { input_tokens: 2, output_tokens: 4 },
+    })
+
+    await vi.waitFor(() => {
+      expect(sessionsApi.getMessages).toHaveBeenCalledTimes(2)
+    })
+    expect(useChatStore.getState().sessions[TEST_SESSION_ID]?.messages).toEqual([
+      expect.objectContaining({ type: 'user_text', content: 'Hello' }),
+      expect.objectContaining({
+        type: 'assistant_text',
+        content: 'Hello! Is this message visible now?',
+      }),
+    ])
+  })
+
   it('keeps the tab running for background agents when reconnect reconciliation finds the foreground idle', () => {
     useChatStore.setState({
       sessions: {

--- a/desktop/src/stores/chatStore.ts
+++ b/desktop/src/stores/chatStore.ts
@@ -345,6 +345,7 @@ type ChatStore = {
     guard?: {
       messages: UIMessage[]
       backgroundAgentTasks?: Record<string, BackgroundAgentTask>
+      preserveUnrestoredCurrentUserMessage?: boolean
     },
   ) => Promise<void>
   queueComposerPrefill: (
@@ -1507,6 +1508,58 @@ function mergeRestoredHistoryIntoLiveMessages(
   )
 }
 
+function preserveUnrestoredCurrentUserMessage(
+  restoredMessages: UIMessage[],
+  liveMessages: UIMessage[],
+): UIMessage[] {
+  let liveUserIndex = -1
+  for (let index = liveMessages.length - 1; index >= 0; index--) {
+    if (liveMessages[index]?.type !== 'user_text') continue
+    liveUserIndex = index
+    break
+  }
+  if (liveUserIndex === -1) return restoredMessages
+
+  const liveUser = liveMessages[liveUserIndex]
+  if (liveUser?.type !== 'user_text') return restoredMessages
+
+  const restoredHasUser = liveUser.transcriptMessageId
+    ? restoredMessages.some((message) =>
+        message.type === 'user_text' &&
+        message.transcriptMessageId === liveUser.transcriptMessageId)
+    : restoredMessages.filter((message) =>
+        message.type === 'user_text' &&
+        message.content.trim() === liveUser.content.trim()).length >=
+      liveMessages.slice(0, liveUserIndex + 1).filter((message) =>
+        message.type === 'user_text' &&
+        message.content.trim() === liveUser.content.trim()).length
+  if (restoredHasUser) return restoredMessages
+
+  const liveReply = liveMessages.slice(liveUserIndex + 1).find((message) =>
+    message.type === 'assistant_text' && message.content.trim().length > 0)
+  let insertionIndex = liveReply?.type === 'assistant_text'
+    ? restoredMessages.findIndex((message) =>
+        message.type === 'assistant_text' &&
+        (
+          (liveReply.transcriptMessageId &&
+            message.transcriptMessageId === liveReply.transcriptMessageId) ||
+          message.content.trim() === liveReply.content.trim()
+        ))
+    : -1
+
+  if (insertionIndex === -1) {
+    insertionIndex = restoredMessages.findIndex((message) =>
+      message.timestamp >= liveUser.timestamp)
+  }
+  if (insertionIndex === -1) insertionIndex = restoredMessages.length
+
+  return [
+    ...restoredMessages.slice(0, insertionIndex),
+    liveUser,
+    ...restoredMessages.slice(insertionIndex),
+  ]
+}
+
 function needsTranscriptIdHydrationRetry(session: PerSessionState | undefined): boolean {
   if (!session || session.chatState !== 'idle') return false
 
@@ -1556,6 +1609,7 @@ function reconcileCompletedTranscriptHistory(
   void get().reloadHistory(sessionId, {
     messages: session.messages,
     backgroundAgentTasks: session.backgroundAgentTasks,
+    preserveUnrestoredCurrentUserMessage: true,
   })
 }
 
@@ -2430,7 +2484,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           session.backgroundAgentTasks ?? {},
           restoredBackgroundTasks,
         )
-        const messages = mergeBackgroundTaskMessages(uiMessages, backgroundAgentTasks)
+        let messages = mergeBackgroundTaskMessages(uiMessages, backgroundAgentTasks)
+        if (guard?.preserveUnrestoredCurrentUserMessage) {
+          messages = preserveUnrestoredCurrentUserMessage(messages, guard.messages)
+        }
         historyApplied = true
         return {
           sessions: updateSessionIn(state.sessions, sessionId, () => ({


### PR DESCRIPTION
## Summary

Preserve the current user message when reconnect completion reconciliation replaces the live message list with an authoritative transcript that already contains the assistant reply but not yet the matching user entry.

This prevents a successfully sent user turn from disappearing from the desktop conversation after the model response completes. The reconciliation path is shared by all desktop platforms.

### Root cause

On `message_complete`, the desktop reloads transcript history and replaces the live message list. During a reconnect race, the history response can contain the completed assistant reply while omitting the optimistic current user message. The replacement therefore drops the visible user turn even though the server received it.

The fix preserves only the latest unmatched live user message for this completion-reconciliation path. It inserts the message before the matching restored assistant reply when possible, then falls back to timestamp order. Transcript IDs and repeated-content occurrence counts prevent duplicating a user message that history already restored.

## Feature Quality Contract

- Changed surface: desktop chat store / WebSocket reconnect transcript reconciliation
- Tests added or updated:
  - Added a regression test where reconnect history contains the persisted assistant reply but not the optimistic user message.
  - `desktop/src/stores/chatStore.test.ts`: 226 passed, 0 failed.
- Coverage evidence:
  - `bun run check:coverage`
  - Report: `artifacts/coverage/2026-08-17T09-37-08-486Z/coverage-report.md`
  - Full gate summary: 3 suites passed, 3 suites failed because the Windows runner cannot create test symlinks and existing desktop baseline tests fail on path/theme assertions.
  - Focused desktop coverage: `chatStore.ts` 90.39% line coverage; changed executable lines 90% (45/50), meeting the 90% threshold.
- E2E / live-model evidence:
  - `bun run check:agent-flow`: 8 passed, 0 failed; artifacts: `artifacts/agent-flow`.
  - `bun run check:chat-contract`: conversation suite 112 passed, 2 failed, 1 error; failures were an existing 5-second timeout and Windows temporary-directory `EBUSY` cleanup, not the added regression.
  - Live model: not run; no maintainer authorization or provider quota was used.
- Known risk / rollback:
  - The preservation behavior is restricted to replace-on-completion reconciliation and only applies when the latest live user occurrence is absent from restored history.
  - Revert commit `75f17903` to roll back.

## Verification

- [x] I ran the relevant local checks, or explained why they do not apply.
- [x] I added or updated same-area tests for every production behavior change.
- [ ] I ran the checks selected by `bun run check:impact`; if I claim PR-ready/full validation, I also ran `bun run verify`.
  - `check:desktop` reached 4,379 passed / 14 failed / 2 skipped; failures are existing Windows symlink, path-separator, and theme-baseline failures.
  - `check:server` was stopped after repeated existing Windows symlink/path failures and a prolonged stall.
  - This is submitted as a draft and does not claim full local validation.
- [x] New or changed executable production lines meet the changed-line coverage threshold, or the blocker/maintainer override is documented.
- [x] I attached or summarized the quality report path, JUnit/log artifact path, and pass/fail/skip counts.
- [x] I ran deterministic E2E/contract checks for cross-boundary changes. Live-model evidence is attached when a trusted maintainer ran it, otherwise it is explicitly marked not run.

## Risk

- [x] This PR does not touch CLI core paths, or it has maintainer approval for `allow-cli-core-change`.
- [x] Production code changes include matching tests, or have maintainer approval for `allow-missing-tests`.
- [x] Coverage baseline/threshold changes have maintainer approval for `allow-coverage-baseline-change`.
- [x] Any quarantine-policy change has maintainer approval; deterministic provider/chat contract tests were not quarantined.
- [x] Provider/runtime changes are covered by offline mock/fixture contract tests; live smoke was run by a trusted maintainer or explicitly deferred.