### PR TITLE
fix(diagnostics): keep API route and method in shared diagnostics

### DIFF
--- a/src/server/services/diagnosticsShare.test.ts
+++ b/src/server/services/diagnosticsShare.test.ts
@@ -115,6 +115,99 @@ describe('projectDiagnosticEventForSharing', () => {
     expect(projected.omittedFields).toContain('details.error.message')
     expect(projected.omittedFields).toContain('details.error.stack')
   })
+
+  test('keeps the failing API route and method so 4xx events are attributable', () => {
+    const event: DiagnosticEvent = {
+      id: 'event-api-failure',
+      timestamp: '2026-07-11T09:10:11.000Z',
+      type: 'client_api_request_failed',
+      severity: 'warn',
+      summary: 'GET /api/sessions/... failed',
+      details: {
+        method: 'GET',
+        path: '/api/sessions/f9312a1e-3fe0-42d5-8d2b-522a06146987/messages',
+        status: 404,
+      },
+    }
+
+    const projected = projectDiagnosticEventForSharing(event)
+
+    expect(projected.details).toEqual({
+      method: 'GET',
+      path: '/api/sessions/:id/messages',
+      status: 404,
+    })
+    expect(JSON.stringify(projected)).not.toContain('f9312a1e')
+    expect(projected.omittedFields).not.toContain('details.path')
+    expect(projected.omittedFields).not.toContain('details.method')
+  })
+
+  test('replaces identifier-shaped route segments regardless of position', () => {
+    const event: DiagnosticEvent = {
+      id: 'event-api-ids',
+      timestamp: '2026-07-11T09:10:11.000Z',
+      type: 'client_api_request_failed',
+      severity: 'warn',
+      summary: 'ids',
+      details: {
+        path: '/api/projects/42/files/9f86d081884c7d659a2feaa0c55ad015/raw',
+      },
+    }
+
+    expect(projectDiagnosticEventForSharing(event).details).toEqual({
+      path: '/api/projects/:id/files/:id/raw',
+    })
+  })
+
+  test('strips query strings and fragments while keeping the route', () => {
+    for (const [path, expected] of [
+      ['/api/files?token=query-secret', '/api/files'],
+      ['/api/files#private-fragment', '/api/files'],
+      ['/api/sessions/f9312a1e-3fe0-42d5-8d2b-522a06146987?token=secret', '/api/sessions/:id'],
+    ] as const) {
+      const projected = projectDiagnosticEventForSharing({
+        id: 'event-api-query',
+        timestamp: '2026-07-11T09:10:11.000Z',
+        type: 'client_api_request_failed',
+        severity: 'warn',
+        summary: 'query',
+        details: { path },
+      })
+
+      expect(projected.details?.path).toBe(expected)
+      const serialized = JSON.stringify(projected)
+      expect(serialized).not.toContain('query-secret')
+      expect(serialized).not.toContain('private-fragment')
+      expect(serialized).not.toContain('f9312a1e')
+    }
+  })
+
+  test('omits paths that are not in-app API routes', () => {
+    for (const path of [
+      '/Users/alice/private/project/notes.md',
+      '/home/alice/.ssh/id_rsa',
+      '/api/files/%2Fetc%2Fpasswd',
+      '/api/files/../../etc/passwd',
+      'https://example.com/api/files',
+      '//evil.example.com/api',
+      `/api/${'deep/'.repeat(20)}leaf`,
+    ]) {
+      const projected = projectDiagnosticEventForSharing({
+        id: 'event-api-unsafe',
+        timestamp: '2026-07-11T09:10:11.000Z',
+        type: 'client_api_request_failed',
+        severity: 'warn',
+        summary: 'unsafe',
+        details: { path },
+      })
+
+      expect(projected.details?.path).toBeUndefined()
+      expect(projected.omittedFields).toContain('details.path')
+      expect(JSON.stringify(projected)).not.toContain('query-secret')
+      expect(JSON.stringify(projected)).not.toContain('/Users/alice')
+      expect(JSON.stringify(projected)).not.toContain('passwd')
+    }
+  })
 })
 
 describe('buildDiagnosticsIssueReport', () => {

--- a/src/server/services/diagnosticsShare.ts
+++ b/src/server/services/diagnosticsShare.ts
@@ -47,11 +47,27 @@ const SAFE_SCALAR_KEYS = new Set([
   'is_error',
   'isapierrormessage',
   'iserror',
+  'method',
   'name',
   'sdkType'.toLowerCase(),
   'status',
   'subtype',
 ])
+
+// `path` carries the failing API route, which is what makes an API failure
+// actionable. It cannot go through SAFE_SCALAR_KEYS because it starts with
+// "/" and would be rejected by SAFE_METADATA_VALUE_RE, so it gets a dedicated
+// projection that keeps the route shape and drops everything identifying.
+//
+// Only in-app API routes are echoed back. Anchoring on the "/api/" prefix is
+// what keeps filesystem paths (/Users/..., /home/...) out: their segments are
+// otherwise indistinguishable from route segments.
+const API_PATH_KEYS = new Set(['path'])
+const API_PATH_PREFIX = '/api/'
+const API_PATH_SEGMENT_RE = /^[A-Za-z0-9._-]+$/
+const API_PATH_ID_RE =
+  /^(?:[0-9]+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{16,}|[A-Za-z0-9_-]{24,})$/i
+const MAX_API_PATH_SEGMENTS = 12
 
 const SAFE_METADATA_VALUE_RE = /^[a-z0-9][a-z0-9_.:/ -]{0,127}$/i
 const MAX_SHARED_IDENTIFIER_LENGTH = 256
@@ -230,9 +246,46 @@ function projectDetails(
       projected[key] = projectSafeMetadataScalar(entry)
       continue
     }
+    if (API_PATH_KEYS.has(normalizedKey) && typeof entry === 'string') {
+      const apiPath = projectApiPath(entry)
+      if (apiPath !== null) {
+        projected[key] = apiPath
+        continue
+      }
+    }
     omittedFields.push(entryPath)
   }
   return Object.keys(projected).length > 0 ? projected : undefined
+}
+
+/**
+ * Project an API request path down to its route shape.
+ *
+ * Keeps `/api/sessions/:id/messages` so a maintainer can tell which endpoint
+ * returned 4xx, while dropping query strings, fragments, credentials and any
+ * segment that looks like an identifier. Returns null when the value is not an
+ * in-app API route, in which case the caller omits the field entirely.
+ */
+function projectApiPath(value: string): string | null {
+  const trimmed = value.trim()
+  if (!trimmed.startsWith(API_PATH_PREFIX)) return null
+
+  const withoutQuery = trimmed.split(/[?#]/, 1)[0] ?? ''
+  if (withoutQuery.length === 0 || withoutQuery.length > MAX_SHARED_METADATA_LENGTH) return null
+
+  const segments = withoutQuery.split('/').filter((segment) => segment.length > 0)
+  if (segments.length > MAX_API_PATH_SEGMENTS) return null
+
+  const projectedSegments: string[] = []
+  for (const segment of segments) {
+    // Anything outside a conservative charset (encoded bytes, spaces, dots
+    // traversal, unicode) means this is not a route we can safely echo back.
+    if (!API_PATH_SEGMENT_RE.test(segment)) return null
+    if (segment === '.' || segment === '..') return null
+    projectedSegments.push(API_PATH_ID_RE.test(segment) ? ':id' : segment)
+  }
+
+  return `/${projectedSegments.join('/')}`
 }
 
 function projectError(error: Error): Record<string, string> {


### PR DESCRIPTION
## 问题

`reportApiFailure`（`desktop/src/api/client.ts`）为每个失败请求记录 `{ method, path, errorName, message, status }`，但 `projectDiagnosticEventForSharing` 的 `SAFE_SCALAR_KEYS` 白名单只放行 `status`。

结果是导出诊断包里每条 `client_api_request_failed` 都塌缩成：

```json
{ "status": 404 }
```

`details.method` 和 `details.path` 出现在 `omittedFields` 里。

这让诊断包答不出定位的第一个问题：**是哪个端点失败了**。一份包里可能有几十条 4xx，彼此完全无法区分，维护者拿到 issue 也没法往下走。

## 改动

`method` 是裸 HTTP 动词，直接加入 `SAFE_SCALAR_KEYS`。

`path` 不行 —— 它以 `/` 开头，而 `SAFE_METADATA_VALUE_RE` 要求首字符是字母数字，所以需要单独的投影函数 `projectApiPath`：

- 锚定 `/api/` 前缀。这是把文件系统路径（`/Users/...`、`/home/...`）挡在外面的关键 —— 它们的路径段和路由段在字符层面无法区分，只靠字符集过滤会把用户名原样带出去
- 解析前先剥掉 query string 和 fragment
- 拒绝 `[A-Za-z0-9._-]` 之外的段，percent-encoding 和 `..` 遍历是**拒绝**而不是清洗
- 把 identifier 形状的段（纯数字、uuid、长 hex、长 base64url）改写成 `:id`
- 限制段数上限

效果：

```
/api/sessions/<uuid>/messages?token=x   →   /api/sessions/:id/messages
```

不是 in-app API 路由的值，行为和改动前完全一致（整个字段 omit）。

## 影响范围

server（`src/server/services/diagnosticsShare.ts`）。仅影响诊断包导出时的字段投影，不改变诊断事件的记录方式，也不触及运行时行为。

## 测试说明

`bun test src/server/services/diagnosticsShare.test.ts` — 9 passed。新增 4 个用例：

- 保留路由与 method，同时把 uuid 段改写成 `:id`
- 任意位置的 identifier 段都被改写
- query / fragment 被剥离但路由保留
- 非 in-app 路由（文件系统路径、percent-encoding、路径遍历、绝对 URL、协议相对 URL、超长路径）全部 omit

每个用例都断言原始敏感值不出现在序列化结果里。

本机跑 `bun run check:server` 有大量预先存在的失败（该环境下子进程被 SIGTERM，`exitCode 143`）。已用 `git stash` 在同一环境对基线做对照：基线 51 passed / 39 failed，本分支 55 passed / 39 failed —— 新增的 4 个 pass 正是本 PR 的用例，failed 数不变，无回归。

live model: not run (untrusted fork / no provider)

## 剩余风险

- `/api/` 前缀是基于当前 `desktop/src/api/*` 全部走该前缀这一事实。若将来新增其他前缀的内部 API，其 path 会被静默 omit（退化为当前行为，不会泄露）
- identifier 改写是启发式的。短的非 id 段（如 `raw`、`status`）会原样保留，这是有意的 —— 它们正是路由可读性的来源
