### PR TITLE
fix(desktop): only spawn adapter sidecars that have credentials

### DIFF
--- a/adapters/common/__tests__/config.test.ts
+++ b/adapters/common/__tests__/config.test.ts
@@ -415,6 +415,36 @@ describe('isAdapterConfigured', () => {
   it('treats a blank authDir as unconfigured rather than resolving to cwd', () => {
     expect(hasWhatsAppCreds('')).toBe(false)
   })
+
+  it('distinguishes a malformed config from an empty one only in strict mode', () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adapter-malformed-'))
+    try {
+      fs.writeFileSync(path.join(configDir, 'adapters.json'), 'not json at all')
+
+      // Lenient (the sidecar's path) keeps working off defaults.
+      expect(() => loadConfig({ configDir })).not.toThrow()
+      expect(isAdapterConfigured(loadConfig({ configDir }), 'telegram')).toBe(false)
+
+      // Strict lets a caller tell "cannot read" apart from "nothing
+      // configured" — otherwise a typo is indistinguishable from an empty
+      // config and would silently disable every working adapter.
+      expect(() => loadConfig({ configDir, strict: true })).toThrow()
+    } finally {
+      fs.rmSync(configDir, { recursive: true, force: true })
+    }
+  })
+
+  it('treats a missing config file as empty even in strict mode', () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adapter-missing-'))
+    try {
+      expect(() => loadConfig({ configDir, strict: true })).not.toThrow()
+      const configured = ADAPTER_PLATFORMS.filter((platform) =>
+        isAdapterConfigured(loadConfig({ configDir, strict: true }), platform))
+      expect(configured).toEqual([])
+    } finally {
+      fs.rmSync(configDir, { recursive: true, force: true })
+    }
+  })
 })
 
 function restoreEnv(key: string, value: string | undefined): void {

--- a/adapters/common/__tests__/config.test.ts
+++ b/adapters/common/__tests__/config.test.ts
@@ -2,7 +2,14 @@ import { afterEach, describe, expect, it } from 'bun:test'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import { getConfiguredWorkDir, loadConfig, resolveAllowedProjectRoots } from '../config.js'
+import {
+  ADAPTER_PLATFORMS,
+  getConfiguredWorkDir,
+  hasWhatsAppCreds,
+  isAdapterConfigured,
+  loadConfig,
+  resolveAllowedProjectRoots,
+} from '../config.js'
 
 describe('adapter config defaults', () => {
   const originalConfigDir = process.env.CLAUDE_CONFIG_DIR
@@ -310,6 +317,103 @@ describe('resolveAllowedProjectRoots', () => {
       fs.rmSync(envRoot, { recursive: true, force: true })
       fs.rmSync(fileRoot, { recursive: true, force: true })
     }
+  })
+})
+
+describe('isAdapterConfigured', () => {
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR
+
+  afterEach(() => {
+    restoreEnv('CLAUDE_CONFIG_DIR', originalConfigDir)
+  })
+
+  function withConfigDir(
+    file: Record<string, unknown>,
+    run: (configDir: string) => void,
+  ): void {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adapter-configured-'))
+    try {
+      fs.writeFileSync(path.join(configDir, 'adapters.json'), JSON.stringify(file))
+      run(configDir)
+    } finally {
+      fs.rmSync(configDir, { recursive: true, force: true })
+    }
+  }
+
+  it('requires every credential an adapter needs, not just the first', () => {
+    withConfigDir(
+      {
+        telegram: { botToken: 'token' },
+        feishu: { appId: 'id' },
+        wechat: { accountId: 'account' },
+        dingtalk: { clientId: 'client' },
+      },
+      (configDir) => {
+        const config = loadConfig({ configDir })
+        expect(isAdapterConfigured(config, 'telegram')).toBe(true)
+        // appSecret / botToken / clientSecret are missing
+        expect(isAdapterConfigured(config, 'feishu')).toBe(false)
+        expect(isAdapterConfigured(config, 'wechat')).toBe(false)
+        expect(isAdapterConfigured(config, 'dingtalk')).toBe(false)
+      },
+    )
+  })
+
+  it('treats a fully credentialed config as configured across platforms', () => {
+    withConfigDir(
+      {
+        telegram: { botToken: 'token' },
+        feishu: { appId: 'id', appSecret: 'secret' },
+        wechat: { accountId: 'account', botToken: 'token' },
+        dingtalk: { clientId: 'client', clientSecret: 'secret' },
+      },
+      (configDir) => {
+        const config = loadConfig({ configDir })
+        for (const platform of ['telegram', 'feishu', 'wechat', 'dingtalk'] as const) {
+          expect(isAdapterConfigured(config, platform)).toBe(true)
+        }
+      },
+    )
+  })
+
+  it('reports nothing configured for an empty config', () => {
+    withConfigDir({}, (configDir) => {
+      const config = loadConfig({ configDir })
+      const configured = ADAPTER_PLATFORMS.filter((platform) =>
+        isAdapterConfigured(config, platform))
+      expect(configured).toEqual([])
+    })
+  })
+
+  it('detects WhatsApp only once QR-linked creds exist on disk', () => {
+    const authDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adapter-wa-auth-'))
+    try {
+      withConfigDir({ whatsapp: { authDir } }, (configDir) => {
+        expect(isAdapterConfigured(loadConfig({ configDir }), 'whatsapp')).toBe(false)
+        expect(hasWhatsAppCreds(authDir)).toBe(false)
+
+        fs.writeFileSync(path.join(authDir, 'creds.json'), '{}')
+        expect(isAdapterConfigured(loadConfig({ configDir }), 'whatsapp')).toBe(true)
+        expect(hasWhatsAppCreds(authDir)).toBe(true)
+      })
+    } finally {
+      fs.rmSync(authDir, { recursive: true, force: true })
+    }
+  })
+
+  it('reads the explicit configDir instead of the ambient CLAUDE_CONFIG_DIR', () => {
+    withConfigDir({ telegram: { botToken: 'from-explicit-dir' } }, (explicitDir) => {
+      withConfigDir({}, (ambientDir) => {
+        process.env.CLAUDE_CONFIG_DIR = ambientDir
+        expect(isAdapterConfigured(loadConfig({ configDir: explicitDir }), 'telegram')).toBe(true)
+        // Without the override the ambient (empty) dir wins.
+        expect(isAdapterConfigured(loadConfig(), 'telegram')).toBe(false)
+      })
+    })
+  })
+
+  it('treats a blank authDir as unconfigured rather than resolving to cwd', () => {
+    expect(hasWhatsAppCreds('')).toBe(false)
   })
 })
 

--- a/adapters/common/config.ts
+++ b/adapters/common/config.ts
@@ -90,24 +90,80 @@ export type AdapterPlatformConfig =
   | DingtalkConfig
   | WhatsAppConfig
 
-function getConfigPath(): string {
-  const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude')
-  return path.join(configDir, 'adapters.json')
+export type AdapterPlatform = 'telegram' | 'feishu' | 'wechat' | 'dingtalk' | 'whatsapp'
+
+export const ADAPTER_PLATFORMS: readonly AdapterPlatform[] = [
+  'feishu',
+  'telegram',
+  'wechat',
+  'dingtalk',
+  'whatsapp',
+]
+
+const WHATSAPP_CREDS_FILE = 'creds.json'
+
+/**
+ * Whether a QR-linked WhatsApp account exists on disk.
+ *
+ * Lives here rather than in adapters/whatsapp/session.ts so callers that only
+ * need the check (the Electron host, the sidecar arg gate) do not pull in the
+ * Baileys runtime. session.ts re-exports it as hasWhatsAppAuth.
+ */
+export function hasWhatsAppCreds(authDir: string): boolean {
+  if (!authDir) return false
+  return fs.existsSync(path.join(path.resolve(authDir), WHATSAPP_CREDS_FILE))
 }
 
-function loadFile(): Record<string, any> {
+/**
+ * Whether an adapter has enough credentials to actually start.
+ *
+ * Mirrors the per-adapter guards in desktop/sidecars/claude-sidecar.ts. The
+ * sidecar still enforces these at import time; this lets callers ask the same
+ * question before spawning a process that would only exit(1).
+ */
+export function isAdapterConfigured(config: AdapterConfig, platform: AdapterPlatform): boolean {
+  switch (platform) {
+    case 'telegram':
+      return Boolean(config.telegram.botToken)
+    case 'feishu':
+      return Boolean(config.feishu.appId && config.feishu.appSecret)
+    case 'wechat':
+      return Boolean(config.wechat.accountId && config.wechat.botToken)
+    case 'dingtalk':
+      return Boolean(config.dingtalk.clientId && config.dingtalk.clientSecret)
+    case 'whatsapp':
+      return hasWhatsAppCreds(config.whatsapp.authDir)
+  }
+}
+
+function getConfigPath(configDir?: string): string {
+  const dir = configDir || process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude')
+  return path.join(dir, 'adapters.json')
+}
+
+function loadFile(configDir?: string): Record<string, any> {
   try {
-    return JSON.parse(fs.readFileSync(getConfigPath(), 'utf-8'))
+    return JSON.parse(fs.readFileSync(getConfigPath(configDir), 'utf-8'))
   } catch (err: any) {
     if (err?.code !== 'ENOENT') {
-      console.warn(`[Config] Failed to parse ${getConfigPath()}, using defaults`)
+      console.warn(`[Config] Failed to parse ${getConfigPath(configDir)}, using defaults`)
     }
     return {}
   }
 }
 
-export function loadConfig(): AdapterConfig {
-  const file = loadFile()
+export type LoadConfigOptions = {
+  /**
+   * Config root to read adapters.json from. Defaults to CLAUDE_CONFIG_DIR in
+   * the ambient process env. Callers that carry their own env (the Electron
+   * host injects one) should pass it explicitly rather than rely on
+   * process.env matching.
+   */
+  configDir?: string
+}
+
+export function loadConfig(options?: LoadConfigOptions): AdapterConfig {
+  const file = loadFile(options?.configDir)
   const tg = file.telegram ?? {}
   const fs_ = file.feishu ?? {}
   const wc = file.wechat ?? {}

--- a/adapters/common/config.ts
+++ b/adapters/common/config.ts
@@ -141,13 +141,17 @@ function getConfigPath(configDir?: string): string {
   return path.join(dir, 'adapters.json')
 }
 
-function loadFile(configDir?: string): Record<string, any> {
+function loadFile(configDir?: string, strict = false): Record<string, any> {
   try {
     return JSON.parse(fs.readFileSync(getConfigPath(configDir), 'utf-8'))
   } catch (err: any) {
-    if (err?.code !== 'ENOENT') {
-      console.warn(`[Config] Failed to parse ${getConfigPath(configDir)}, using defaults`)
-    }
+    // A missing file is a valid state — nothing is configured yet — and stays
+    // silent in both modes. A malformed file is a real error, which strict
+    // callers need to tell apart from "no adapters configured" before acting
+    // on the difference.
+    if (err?.code === 'ENOENT') return {}
+    if (strict) throw err
+    console.warn(`[Config] Failed to parse ${getConfigPath(configDir)}, using defaults`)
     return {}
   }
 }
@@ -160,10 +164,15 @@ export type LoadConfigOptions = {
    * process.env matching.
    */
   configDir?: string
+  /**
+   * Throw instead of falling back to defaults when adapters.json exists but
+   * cannot be parsed. A missing file is still an empty config, not an error.
+   */
+  strict?: boolean
 }
 
 export function loadConfig(options?: LoadConfigOptions): AdapterConfig {
-  const file = loadFile(options?.configDir)
+  const file = loadFile(options?.configDir, options?.strict)
   const tg = file.telegram ?? {}
   const fs_ = file.feishu ?? {}
   const wc = file.wechat ?? {}

--- a/adapters/whatsapp/session.ts
+++ b/adapters/whatsapp/session.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import { hasWhatsAppCreds } from '../common/config'
 import {
   DisconnectReason,
   fetchLatestBaileysVersion,
@@ -17,7 +18,7 @@ const LOGGED_OUT_STATUS = DisconnectReason?.loggedOut ?? 401
 const credsSaveQueues = new Map<string, Promise<void>>()
 
 export function hasWhatsAppAuth(authDir: string): boolean {
-  return fs.existsSync(resolveCredsPath(authDir))
+  return hasWhatsAppCreds(authDir)
 }
 
 export function clearWhatsAppAuth(authDir: string): void {

--- a/desktop/electron/services/serverRuntime.test.ts
+++ b/desktop/electron/services/serverRuntime.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import path from 'node:path'
 import { PassThrough } from 'node:stream'
@@ -33,6 +33,46 @@ const sidecarMocks = {
 }
 
 let isolatedConfigDir = ''
+
+/**
+ * Write adapters.json into the isolated config dir.
+ *
+ * Adapters only spawn when credentials are present, so tests that assert on
+ * adapter lifecycle have to declare which platforms are configured.
+ */
+function writeAdapterConfig(platforms: {
+  telegram?: boolean
+  feishu?: boolean
+  wechat?: boolean
+  dingtalk?: boolean
+  whatsapp?: boolean
+}): void {
+  const whatsappAuthDir = path.join(isolatedConfigDir, 'whatsapp-auth')
+  if (platforms.whatsapp) {
+    mkdirSync(whatsappAuthDir, { recursive: true })
+    writeFileSync(path.join(whatsappAuthDir, 'creds.json'), '{}')
+  }
+  writeFileSync(
+    path.join(isolatedConfigDir, 'adapters.json'),
+    JSON.stringify({
+      ...(platforms.telegram ? { telegram: { botToken: 'test-bot-token' } } : {}),
+      ...(platforms.feishu ? { feishu: { appId: 'test-app-id', appSecret: 'test-app-secret' } } : {}),
+      ...(platforms.wechat ? { wechat: { accountId: 'test-account', botToken: 'test-token' } } : {}),
+      ...(platforms.dingtalk
+        ? { dingtalk: { clientId: 'test-client-id', clientSecret: 'test-client-secret' } }
+        : {}),
+      whatsapp: { authDir: whatsappAuthDir },
+    }),
+  )
+}
+
+const ALL_ADAPTERS_CONFIGURED = {
+  telegram: true,
+  feishu: true,
+  wechat: true,
+  dingtalk: true,
+  whatsapp: true,
+} as const
 
 class FakeSidecarChild extends EventEmitter {
   readonly stdout = new PassThrough()
@@ -77,6 +117,7 @@ async function waitForServerChildren(count: number): Promise<void> {
 describe('ElectronServerRuntime', () => {
   beforeEach(() => {
     isolatedConfigDir = mkdtempSync(path.join(tmpdir(), 'cc-haha-electron-runtime-'))
+    writeAdapterConfig(ALL_ADAPTERS_CONFIGURED)
     sidecarMocks.nextPort = 49321
     sidecarMocks.spawnError = null
     sidecarMocks.serverChildren.length = 0
@@ -90,6 +131,42 @@ describe('ElectronServerRuntime', () => {
 
   afterEach(() => {
     rmSync(isolatedConfigDir, { recursive: true, force: true })
+  })
+
+  it('only spawns adapters that have credentials', async () => {
+    writeAdapterConfig({ telegram: true })
+
+    const runtime = createRuntime({ appRoot: '/isolated/app' })
+    await runtime.getServerUrl()
+
+    expect(sidecarMocks.adapterChildren).toHaveLength(1)
+    // createAdapterPlan builds ['adapters', '--app-root', <root>, <flag>],
+    // so the platform flag is the trailing arg.
+    const adapterFlags = sidecarMocks.spawnSidecar.mock.calls
+      .map(([plan]) => plan.args)
+      .filter(args => args[0] === 'adapters')
+      .map(args => args.at(-1))
+    expect(adapterFlags).toEqual(['--telegram'])
+  })
+
+  it('spawns no adapters when adapters.json declares no credentials', async () => {
+    writeAdapterConfig({})
+
+    const runtime = createRuntime({ appRoot: '/isolated/app' })
+    await runtime.getServerUrl()
+
+    expect(sidecarMocks.adapterChildren).toHaveLength(0)
+  })
+
+  it('falls back to spawning every adapter when the config cannot be read', async () => {
+    writeFileSync(path.join(isolatedConfigDir, 'adapters.json'), 'not json at all')
+
+    const runtime = createRuntime({ appRoot: '/isolated/app' })
+    await runtime.getServerUrl()
+
+    // An unreadable config must not silently disable working integrations;
+    // the sidecar still refuses uncredentialed adapters on its own.
+    expect(sidecarMocks.adapterChildren).toHaveLength(5)
   })
 
   it('restarts after the active healthy server exits and ignores its late exit', async () => {

--- a/desktop/electron/services/serverRuntime.test.ts
+++ b/desktop/electron/services/serverRuntime.test.ts
@@ -48,6 +48,10 @@ function writeAdapterConfig(platforms: {
   whatsapp?: boolean
 }): void {
   const whatsappAuthDir = path.join(isolatedConfigDir, 'whatsapp-auth')
+  // Rewrite, not merge: WhatsApp is credentialed by a file on disk, so leaving
+  // a previous call's creds.json behind would keep it "configured" no matter
+  // what this call declares.
+  rmSync(whatsappAuthDir, { recursive: true, force: true })
   if (platforms.whatsapp) {
     mkdirSync(whatsappAuthDir, { recursive: true })
     writeFileSync(path.join(whatsappAuthDir, 'creds.json'), '{}')

--- a/desktop/electron/services/serverRuntime.ts
+++ b/desktop/electron/services/serverRuntime.ts
@@ -287,7 +287,7 @@ export class ElectronServerRuntime {
    */
   private readAdapterConfig(): AdapterConfig | null {
     try {
-      return loadConfig({ configDir: this.baseEnv.CLAUDE_CONFIG_DIR })
+      return loadConfig({ configDir: this.baseEnv.CLAUDE_CONFIG_DIR, strict: true })
     } catch (error) {
       console.error('[desktop] failed to read adapter config; starting all adapters', error)
       return null

--- a/desktop/electron/services/serverRuntime.ts
+++ b/desktop/electron/services/serverRuntime.ts
@@ -27,6 +27,11 @@ import {
 } from './sidecarManager'
 import { readDesktopTerminalConfig, resolveDesktopTerminalShell } from './terminal'
 import {
+  isAdapterConfigured,
+  loadConfig,
+  type AdapterConfig,
+} from '../../../adapters/common/config'
+import {
   SystemProxyBridge,
   type SystemProxyBridgeLike,
 } from './systemProxyBridge'
@@ -273,6 +278,22 @@ export class ElectronServerRuntime {
     if (generation !== this.lifecycleGeneration) throw new Error('server startup stopped')
   }
 
+  /**
+   * Read adapter credentials, or null when they cannot be read.
+   *
+   * Returning null deliberately falls back to spawning every adapter: a
+   * config that cannot be parsed should not silently disable working
+   * integrations. The sidecar still refuses to start uncredentialed adapters.
+   */
+  private readAdapterConfig(): AdapterConfig | null {
+    try {
+      return loadConfig({ configDir: this.baseEnv.CLAUDE_CONFIG_DIR })
+    } catch (error) {
+      console.error('[desktop] failed to read adapter config; starting all adapters', error)
+      return null
+    }
+  }
+
   private async startAdaptersSidecars(
     serverUrl: string,
     startState?: ServerStartState,
@@ -291,6 +312,10 @@ export class ElectronServerRuntime {
     if (!isCurrentGeneration()) return
     const ownedAdapters = startState?.adapterChildren
       ?? activeServer?.adapterChildren
+    // Spawning an adapter without credentials costs a process launch and
+    // produces a guaranteed exit(1), so ask the same question the sidecar
+    // would ask on startup before paying for it.
+    const adapterConfig = this.readAdapterConfig()
     for (const [label, flag] of [
       ['feishu', '--feishu'],
       ['telegram', '--telegram'],
@@ -299,6 +324,7 @@ export class ElectronServerRuntime {
       ['whatsapp', '--whatsapp'],
     ] as const) {
       if (!isCurrentGeneration()) break
+      if (adapterConfig && !isAdapterConfigured(adapterConfig, label)) continue
       try {
         const child = this.deps.spawnSidecar(createAdapterPlan({
           desktopRoot: this.desktopRoot,


### PR DESCRIPTION
## 问题

`startAdaptersSidecars`（`desktop/electron/services/serverRuntime.ts`）无条件 spawn 全部五个 adapter sidecar：

```ts
for (const [label, flag] of [
  ['feishu', '--feishu'],
  ['telegram', '--telegram'],
  ['wechat', '--wechat'],
  ['dingtalk', '--dingtalk'],
  ['whatsapp', '--whatsapp'],
] as const) {
```

每个 sidecar 启动后加载配置、发现没有凭据、打一条 warning、`exit(1)`。

只配了一个 adapter 的用户，每次 server 启动要付四次无效的进程 spawn；host 日志里稳定出现四条 `sidecar exited (code=1)` 和 `no adapter could be started` —— 看起来像故障，实际是预期稳态。这在并发负载较重的机器上是实打实的开销，也让日志噪音掩盖真正的启动失败。

凭据检查其实**已经存在**于 `desktop/sidecars/claude-sidecar.ts`，只是发生在 spawn 之后。本 PR 把同一个判断提到 spawn 之前。

## 改动

- `adapters/common/config.ts` 新增 `isAdapterConfigured()`，逐字对应 `claude-sidecar.ts` 里的各 adapter 守卫条件
- 同文件新增 `hasWhatsAppCreds()`。WhatsApp 的判断原本在 `adapters/whatsapp/session.ts`，而该文件顶层 import 了 `@whiskeysockets/baileys` —— Electron 主进程不应为了一次 `existsSync` 拉进整个 Baileys 运行时。`session.ts` 保留 `hasWhatsAppAuth` 这个公开名并委托过去，保持单一真相源
- `loadConfig()` 增加可选的 `configDir`。Electron host 持有注入的 env（`options.env ?? process.env`），不能假设 ambient `process.env` 与之一致，因此显式传 `baseEnv.CLAUDE_CONFIG_DIR`
- `serverRuntime` 在 spawn 前跳过无凭据的 adapter

配置**读不到或解析失败时回退到全部启动**。这里 fail-closed 是错的：一个格式错误不该静默关掉正在工作的集成；而 sidecar 自己仍会拒绝无凭据的 adapter，所以这个回退除了一条日志之外没有代价。

## 影响范围

desktop（Electron host）+ adapter（`adapters/common/config.ts`、`adapters/whatsapp/session.ts`）。

不改变 sidecar 侧任何既有行为，`hasWhatsAppAuth` 的签名与语义不变。

## 测试说明

`desktop/electron/services/serverRuntime.test.ts` 新增 3 个用例：

- 只配 telegram 时只 spawn 一个，且 flag 确为 `--telegram`
- 空配置时不 spawn 任何 adapter
- 配置无法解析时回退到全部 5 个

现有 adapter 生命周期用例依赖"启动 5 个"这一前提，因此 `beforeEach` 现在会往隔离的 `CLAUDE_CONFIG_DIR` 写入一份全凭据 `adapters.json`（新增 `writeAdapterConfig` helper），测试意图不变。

**本机未能执行 desktop 测试**：该环境下 `bun install` 无法完成（网络受限），`desktop/node_modules` 为空，vitest 跑不起来。已做的替代验证：

- `isAdapterConfigured` / `loadConfig({ configDir })` 的行为用 `bun test` 单独跑通（含"feishu 只有 appId 缺 appSecret 判定为未配置"这类边界）
- 四个改动文件全部通过 `Bun.Transpiler` 语法检查
- 相对 import 路径均已确认可解析
- 静态核对了 `createAdapterPlan` 生成的 `args` 形状为 `['adapters', '--app-root', <root>, <flag>]`，据此断言尾部参数（早期写法用 `find(startsWith('--'))` 会错误匹配到 `--app-root`，已修正）

请 CI 执行 `check:electron` / `check:adapters` 复核。

live model: not run (untrusted fork / no provider)

## 剩余风险

- desktop 测试未在本机实跑，见上
- `isAdapterConfigured` 与 `claude-sidecar.ts` 的守卫条件目前靠人工对齐。两处若将来分叉，表现是"host 跳过了但 sidecar 本可启动"（或反之）。若维护者认为值得，可以让 `claude-sidecar.ts` 直接调用 `isAdapterConfigured` 来消除这份重复 —— 本 PR 没有这么做，是为了不改动 sidecar 的既有行为
