### PR TITLE
fix(models): make xhigh effort reachable and list Opus 5

### DIFF
--- a/desktop/src/constants/modelCatalog.test.ts
+++ b/desktop/src/constants/modelCatalog.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { OFFICIAL_DEFAULT_MODEL_ID, OFFICIAL_MODELS } from './modelCatalog'
+
+/**
+ * The effort levels a model may declare.
+ *
+ * Duplicated deliberately rather than imported: the point of these tests is to
+ * catch this list drifting apart from its other copies, so importing one of
+ * them would defeat the check. Keep in step with EFFORT_LEVELS in
+ * src/server/api/models.ts, VALID_SESSION_EFFORT_LEVELS in
+ * src/server/services/sessionService.ts, and EFFORT_LEVELS in
+ * desktop/src/lib/persistenceMigrations.ts.
+ */
+const EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const
+
+describe('OFFICIAL_MODELS', () => {
+  it('lists the current Opus alongside the previous one', () => {
+    const ids = OFFICIAL_MODELS.map((model) => model.id)
+    expect(ids).toContain('claude-opus-5')
+    expect(ids).toContain('claude-opus-4-8')
+  })
+
+  it('has no duplicate model ids', () => {
+    const ids = OFFICIAL_MODELS.map((model) => model.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('points the default at a model that is actually listed', () => {
+    expect(OFFICIAL_MODELS.map((model) => model.id)).toContain(OFFICIAL_DEFAULT_MODEL_ID)
+  })
+
+  it('offers every effort level on models that support reasoning effort', () => {
+    // A model missing from this catalog falls back to a level list that drops
+    // xhigh (see runtimeEffortOptions in components/controls/ModelSelector.tsx),
+    // so an unlisted model silently loses a level that the runtime accepts.
+    const reasoningModels = OFFICIAL_MODELS.filter(
+      (model) => model.supportedReasoningEfforts !== undefined,
+    )
+    expect(reasoningModels.length).toBeGreaterThan(0)
+
+    for (const model of reasoningModels) {
+      expect(model.supportedReasoningEfforts, `${model.id} effort levels`)
+        .toEqual([...EFFORT_LEVELS])
+    }
+  })
+
+  it('keeps each declared default effort within that model own supported set', () => {
+    for (const model of OFFICIAL_MODELS) {
+      if (!model.defaultReasoningEffort) continue
+      expect(model.supportedReasoningEfforts, `${model.id} declares a default but no set`)
+        .toBeDefined()
+      expect(model.supportedReasoningEfforts, `${model.id} default effort`)
+        .toContain(model.defaultReasoningEffort)
+    }
+  })
+})

--- a/desktop/src/constants/modelCatalog.ts
+++ b/desktop/src/constants/modelCatalog.ts
@@ -10,9 +10,17 @@ export const OFFICIAL_MODELS: ModelInfo[] = [
     context: '1m',
   },
   {
+    id: 'claude-opus-5',
+    name: 'Opus 5',
+    description: 'Best for complex agentic coding and enterprise work',
+    context: '1m',
+    defaultReasoningEffort: 'high',
+    supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+  },
+  {
     id: 'claude-opus-4-8',
     name: 'Opus 4.8',
-    description: 'Best for complex agentic coding and enterprise work',
+    description: 'Previous Opus version',
     context: '1m',
     defaultReasoningEffort: 'high',
     supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],

--- a/src/server/__tests__/e2e/business-flow.test.ts
+++ b/src/server/__tests__/e2e/business-flow.test.ts
@@ -417,7 +417,7 @@ describe('Business Flow: Models & Effort', () => {
   it('should default effort to max', async () => {
     const { data } = await api('GET', '/api/effort')
     expect(data.level).toBe('max')
-    expect(data.available).toEqual(['low', 'medium', 'high', 'max'])
+    expect(data.available).toEqual(['low', 'medium', 'high', 'xhigh', 'max'])
   })
 
   it('should set effort to max', async () => {

--- a/src/server/__tests__/e2e/business-flow.test.ts
+++ b/src/server/__tests__/e2e/business-flow.test.ts
@@ -374,9 +374,10 @@ describe('Business Flow: Models & Effort', () => {
 
   it('should return available fallback models', async () => {
     const { data } = await api('GET', '/api/models')
-    expect(data.models.length).toBe(4)
+    expect(data.models.length).toBe(5)
     const names = data.models.map((m: any) => m.name)
     expect(names).toContain('Fable 5')
+    expect(names).toContain('Opus 5')
     expect(names).toContain('Opus 4.8')
     expect(names).toContain('Sonnet 5')
     expect(names).toContain('Haiku 4.5')

--- a/src/server/__tests__/settings.test.ts
+++ b/src/server/__tests__/settings.test.ts
@@ -1186,7 +1186,7 @@ describe('Models API', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.level).toBe('max')
-    expect(body.available).toEqual(['low', 'medium', 'high', 'max'])
+    expect(body.available).toEqual(['low', 'medium', 'high', 'xhigh', 'max'])
   })
 
   it('GET /api/effort should fall back when stored effort is stale', async () => {
@@ -1199,7 +1199,7 @@ describe('Models API', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.level).toBe('max')
-    expect(body.available).toEqual(['low', 'medium', 'high', 'max'])
+    expect(body.available).toEqual(['low', 'medium', 'high', 'xhigh', 'max'])
   })
 
   it('PUT /api/effort should set effort level', async () => {
@@ -1216,6 +1216,32 @@ describe('Models API', () => {
     const { req, url, segments } = makeRequest('PUT', '/api/effort', { level: 'turbo' })
     const res = await handleModelsApi(req, url, segments)
     expect(res.status).toBe(400)
+  })
+
+  it('PUT /api/effort should accept xhigh', async () => {
+    const { req, url, segments } = makeRequest('PUT', '/api/effort', { level: 'xhigh' })
+    const res = await handleModelsApi(req, url, segments)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.level).toBe('xhigh')
+  })
+
+  it('GET /api/effort should preserve a stored xhigh instead of falling back', async () => {
+    const settingsSvc = new SettingsService()
+    await settingsSvc.updateUserSettings({ effort: 'xhigh' })
+
+    const { req, url, segments } = makeRequest('GET', '/api/effort')
+    const res = await handleModelsApi(req, url, segments)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    // The runtime already honours a stored xhigh (getDefaultRuntimeSettings
+    // reads userSettings.effort directly), so normalising it away here made the
+    // UI disagree with what the session actually ran at.
+    expect(body.level).toBe('xhigh')
+    expect(body.available).toContain('xhigh')
   })
 
   it('should return 404 for unknown models endpoint', async () => {

--- a/src/server/__tests__/settings.test.ts
+++ b/src/server/__tests__/settings.test.ts
@@ -720,9 +720,17 @@ describe('Models API', () => {
         context: '1m',
       },
       {
+        id: 'claude-opus-5',
+        name: 'Opus 5',
+        description: 'Best for complex agentic coding and enterprise work',
+        context: '1m',
+        defaultReasoningEffort: 'high',
+        supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+      },
+      {
         id: 'claude-opus-4-8',
         name: 'Opus 4.8',
-        description: 'Best for complex agentic coding and enterprise work',
+        description: 'Previous Opus version',
         context: '1m',
         defaultReasoningEffort: 'high',
         supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
@@ -932,6 +940,7 @@ describe('Models API', () => {
     const listBody = await listResponse.json()
     expect(listBody.models.map((model: { id: string }) => model.id)).toEqual([
       'claude-fable-5',
+      'claude-opus-5',
       'claude-opus-4-8',
       'claude-sonnet-5',
       'claude-haiku-4-5',

--- a/src/server/api/models.ts
+++ b/src/server/api/models.ts
@@ -52,9 +52,17 @@ const DEFAULT_MODELS = [
     context: '1m',
   },
   {
+    id: 'claude-opus-5',
+    name: 'Opus 5',
+    description: 'Best for complex agentic coding and enterprise work',
+    context: '1m',
+    defaultReasoningEffort: 'high',
+    supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+  },
+  {
     id: 'claude-opus-4-8',
     name: 'Opus 4.8',
-    description: 'Best for complex agentic coding and enterprise work',
+    description: 'Previous Opus version',
     context: '1m',
     defaultReasoningEffort: 'high',
     supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],

--- a/src/server/api/models.ts
+++ b/src/server/api/models.ts
@@ -75,7 +75,13 @@ const DEFAULT_MODELS = [
   },
 ] as const
 
-const EFFORT_LEVELS = ['low', 'medium', 'high', 'max'] as const
+// Keep in step with VALID_SESSION_EFFORT_LEVELS (services/sessionService.ts),
+// EFFORT_LEVELS (desktop/src/lib/persistenceMigrations.ts) and the per-model
+// supportedReasoningEfforts in desktop/src/constants/modelCatalog.ts. Omitting
+// a level here does not disable it — the runtime reads userSettings.effort
+// directly — it only makes the level unreachable through this endpoint while
+// still being live in the session.
+const EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const
 
 const DEFAULT_MODEL = 'claude-opus-4-8'
 const DEFAULT_EFFORT = 'max'


### PR DESCRIPTION
## 问题

`xhigh` 在除了一个地方之外的所有地方都是合法档位，而那一个地方恰好是 UI 的必经之路，导致它**既选不了也存不住**。

两个独立成因：

### 1. 全局 effort 端点的档位表漏了 xhigh

```ts
// src/server/api/models.ts:78
const EFFORT_LEVELS = ['low', 'medium', 'high', 'max']              // ← 缺 xhigh
```

而另外三处都有：

| 位置 | 含 xhigh |
|---|---|
| `src/server/services/sessionService.ts` `VALID_SESSION_EFFORT_LEVELS` | ✅ |
| `desktop/src/lib/persistenceMigrations.ts` `EFFORT_LEVELS` | ✅ |
| `desktop/src/constants/modelCatalog.ts` 各模型的 `supportedReasoningEfforts` | ✅ |

于是 `PUT /api/effort {level:'xhigh'}` 返回 400，`GET` 会把已存的 `xhigh` normalize 成 `DEFAULT_EFFORT`。

**这不只是显示问题。** `getDefaultRuntimeSettings`（`src/server/ws/handler.ts`）直接读 `userSettings.effort`，不经过那个 normalize：

```ts
let effort = typeof userSettings.effort === 'string' && userSettings.effort.trim()
  ? userSettings.effort : undefined
```

所以一份 `effort: "xhigh"` 的配置**会真的以 xhigh 跑会话**，但端点报告的是别的值，而且 UI 的任何一次写入都会静默把它替换掉。配置层和展示层对同一个值给出不同答案。

### 2. `claude-opus-5` 不在 `OFFICIAL_MODELS` 里

不在目录里的模型会走 `ModelSelector` 的 `runtimeEffortOptions` 兜底分支：

```ts
const runtimeEffortOptions = supportedRuntimeEfforts === undefined
  ? EFFORT_OPTIONS.filter((option) => option.value !== 'xhigh')   // 明确剔除
  : EFFORT_OPTIONS.filter((option) => supportedRuntimeEfforts.includes(option.value))
```

结果是 Opus 5 只有 4 档，而 Opus 4.8 有 5 档。

## 改动

- `EFFORT_LEVELS` 补上 `'xhigh'`，与其余三处对齐，并加注释说明这几处必须同步
- `OFFICIAL_MODELS` 加入 `claude-opus-5`，effort 集与 Opus 4.8 一致；4.8 的描述改为 previous version

`OFFICIAL_DEFAULT_MODEL_ID` 和 `CLAUDE_OFFICIAL_OPUS_MODEL_ID` **有意未动** —— 默认用哪个模型是产品决策，与哪些模型可选是两回事，留给维护者定。

## 影响范围

server（`src/server/api/models.ts`）+ desktop（`desktop/src/constants/modelCatalog.ts`）。

不改变运行时既有行为：`xhigh` 本来就能跑，本 PR 只是让它在 API 和 UI 层可达。

## 测试说明

**这次是实跑端点验证的，不是读代码推断的。** 先写测试跑出失败基线：

```
PUT /api/effort {level:'xhigh'}   →  400          (修复后 200)
GET /api/effort  (已存 xhigh)      →  "max"        (修复后 "xhigh")
```

- `bun test src/server/__tests__/settings.test.ts` — **74 passed**（新增 2 个：PUT 接受 xhigh、GET 保留 xhigh）
- `npx vitest run src/constants/modelCatalog.test.ts` — **5 passed**（新文件）
- `npx vitest run src/lib/runtimeSelection.test.ts src/lib/persistenceMigrations.test.ts src/constants/modelCatalog.test.ts` — **30 passed**，确认无回归

新增的 `modelCatalog.test.ts` 里有一条防复发的守卫：任何声明了 `supportedReasoningEfforts` 的模型都必须列全五档，档位表再次分叉时会直接失败。该文件**有意不 import** 其它三处的常量——导入其中之一就等于放弃了这个检查。

同时更新了三处硬编码 4 档的断言（`settings.test.ts` ×2、`e2e/business-flow.test.ts` ×1）。

live model: not run (untrusted fork / no provider)

## 剩余风险

- `src/utils/settings/types.ts` 里 CLI 本体的 `effortLevel` schema 对外部用户只允许 `['low','medium','high']`，与本 PR 的 `effort` 是不同字段、不同层，**未触碰**（属于 CLI core）。若两者本应统一，需要维护者另行决定
- Opus 5 的 effort 集是照搬 Opus 4.8 的。若官方实际支持的档位不同，以维护者掌握的信息为准
