### PR TITLE
fix(telegram): resolve partial reply truncation in Telegram bot

### DIFF
--- a/adapters/common/format.ts
+++ b/adapters/common/format.ts
@@ -54,6 +54,12 @@ export function splitMessage(text: string, limit: number): string[] {
     if (splitAt <= 0) splitAt = remaining.lastIndexOf(' ', limit)
     if (splitAt <= 0) splitAt = limit
 
+    // Avoid splitting inside a UTF-16 surrogate pair (e.g. emoji)
+    if (splitAt > 0 && splitAt < remaining.length) {
+      const code = remaining.charCodeAt(splitAt)
+      if (code >= 0xDC00 && code <= 0xDFFF) splitAt -= 1
+    }
+
     // Include the delimiter for paragraph/sentence breaks
     if (remaining[splitAt] === '\n' || remaining[splitAt] === '.') splitAt += 1
 

--- a/adapters/telegram/format.ts
+++ b/adapters/telegram/format.ts
@@ -42,7 +42,8 @@ export function planTelegramStreamingUpdate(
   limit: number,
 ): TelegramStreamingUpdate {
   const fullText = currentText + deltaText
-  if (formatTelegramOutboundText(fullText).length <= limit) {
+  // Reserve 2 chars for the streaming cursor "▍" appended by formatTelegramStreamingText
+  if (formatTelegramOutboundText(fullText).length + 2 <= limit) {
     return { sealedChunks: [], activeChunk: fullText }
   }
 

--- a/adapters/telegram/index.ts
+++ b/adapters/telegram/index.ts
@@ -228,9 +228,20 @@ async function flushToTelegram(chatId: string, newText: string, isComplete: bool
       const chunks = splitMessage(formatTelegramOutboundText(fullText), TELEGRAM_TEXT_LIMIT)
       try {
         await bot.api.editMessageText(numericChatId, placeholder.messageId, chunks[0]!)
-      } catch { /* ignore */ }
+      } catch (err) {
+        console.error('[Telegram] editMessageText (complete) failed, sending as new message:', err instanceof Error ? err.message : err)
+        try {
+          await bot.api.sendMessage(numericChatId, chunks[0]!)
+        } catch (sendErr) {
+          console.error('[Telegram] fallback sendMessage (complete chunk 0) failed:', sendErr instanceof Error ? sendErr.message : sendErr)
+        }
+      }
       for (let i = 1; i < chunks.length; i++) {
-        await bot.api.sendMessage(numericChatId, chunks[i]!)
+        try {
+          await bot.api.sendMessage(numericChatId, chunks[i]!)
+        } catch (err) {
+          console.error('[Telegram] sendMessage (complete chunk) failed:', err instanceof Error ? err.message : err)
+        }
       }
     } else {
       const { sealedChunks, activeChunk } = planTelegramStreamingUpdate(
@@ -239,29 +250,58 @@ async function flushToTelegram(chatId: string, newText: string, isComplete: bool
         TELEGRAM_STREAMING_TEXT_LIMIT,
       )
       accumulatedText.set(chatId, activeChunk)
-      try {
-        const firstSealedChunk = sealedChunks.shift()
-        if (firstSealedChunk) {
-          const firstSealedFormattedChunks = splitMessage(
-            formatTelegramOutboundText(firstSealedChunk),
-            TELEGRAM_TEXT_LIMIT,
-          )
+      const firstSealedChunk = sealedChunks.shift()
+      if (firstSealedChunk) {
+        const firstSealedFormattedChunks = splitMessage(
+          formatTelegramOutboundText(firstSealedChunk),
+          TELEGRAM_TEXT_LIMIT,
+        )
+        try {
           await bot.api.editMessageText(numericChatId, placeholder.messageId, firstSealedFormattedChunks[0]!)
-          for (let i = 1; i < firstSealedFormattedChunks.length; i++) {
-            await bot.api.sendMessage(numericChatId, firstSealedFormattedChunks[i]!)
+        } catch (err) {
+          console.error('[Telegram] editMessageText (streaming) failed, sending as new message:', err instanceof Error ? err.message : err)
+          try {
+            await bot.api.sendMessage(numericChatId, firstSealedFormattedChunks[0]!)
+          } catch (sendErr) {
+            console.error('[Telegram] fallback sendMessage (streaming chunk 0) failed:', sendErr instanceof Error ? sendErr.message : sendErr)
           }
-          for (const chunk of sealedChunks) {
-            const formattedChunks = splitMessage(formatTelegramOutboundText(chunk), TELEGRAM_TEXT_LIMIT)
-            for (const formattedChunk of formattedChunks) {
+        }
+        for (let i = 1; i < firstSealedFormattedChunks.length; i++) {
+          try {
+            await bot.api.sendMessage(numericChatId, firstSealedFormattedChunks[i]!)
+          } catch (err) {
+            console.error('[Telegram] sendMessage (streaming sealed) failed:', err instanceof Error ? err.message : err)
+          }
+        }
+        for (const chunk of sealedChunks) {
+          const formattedChunks = splitMessage(formatTelegramOutboundText(chunk), TELEGRAM_TEXT_LIMIT)
+          for (const formattedChunk of formattedChunks) {
+            try {
               await bot.api.sendMessage(numericChatId, formattedChunk)
+            } catch (err) {
+              console.error('[Telegram] sendMessage (streaming sealed) failed:', err instanceof Error ? err.message : err)
             }
           }
+        }
+        try {
           const sent = await bot.api.sendMessage(numericChatId, formatTelegramStreamingText(activeChunk))
           placeholders.set(chatId, { chatId, messageId: sent.message_id })
-        } else {
-          await bot.api.editMessageText(numericChatId, placeholder.messageId, formatTelegramStreamingText(activeChunk))
+        } catch (err) {
+          console.error('[Telegram] sendMessage (streaming active) failed:', err instanceof Error ? err.message : err)
         }
-      } catch { /* ignore */ }
+      } else {
+        try {
+          await bot.api.editMessageText(numericChatId, placeholder.messageId, formatTelegramStreamingText(activeChunk))
+        } catch (err) {
+          console.error('[Telegram] editMessageText (streaming single) failed, sending as new message:', err instanceof Error ? err.message : err)
+          try {
+            const sent = await bot.api.sendMessage(numericChatId, formatTelegramStreamingText(activeChunk))
+            placeholders.set(chatId, { chatId, messageId: sent.message_id })
+          } catch (sendErr) {
+            console.error('[Telegram] fallback sendMessage (streaming single) failed:', sendErr instanceof Error ? sendErr.message : sendErr)
+          }
+        }
+      }
     }
   } else if (isComplete && (prev + newText).trim()) {
     const fullText = prev + newText
@@ -475,13 +515,24 @@ async function handleServerMessage(chatId: string, msg: ServerMessage): Promise<
       if (placeholders.has(chatId)) {
         const text = accumulatedText.get(chatId)
         if (text?.trim()) {
+          const chunks = splitMessage(formatTelegramOutboundText(text), TELEGRAM_TEXT_LIMIT)
           try {
-            const chunks = splitMessage(formatTelegramOutboundText(text), TELEGRAM_TEXT_LIMIT)
             await bot.api.editMessageText(numericChatId, placeholders.get(chatId)!.messageId, chunks[0]!)
-            for (let i = 1; i < chunks.length; i++) {
-              await bot.api.sendMessage(numericChatId, chunks[i]!)
+          } catch (err) {
+            console.error('[Telegram] editMessageText (message_complete) failed, sending as new message:', err instanceof Error ? err.message : err)
+            try {
+              await bot.api.sendMessage(numericChatId, chunks[0]!)
+            } catch (sendErr) {
+              console.error('[Telegram] fallback sendMessage (message_complete chunk 0) failed:', sendErr instanceof Error ? sendErr.message : sendErr)
             }
-          } catch { /* ignore */ }
+          }
+          for (let i = 1; i < chunks.length; i++) {
+            try {
+              await bot.api.sendMessage(numericChatId, chunks[i]!)
+            } catch (err) {
+              console.error('[Telegram] sendMessage (message_complete chunk) failed:', err instanceof Error ? err.message : err)
+            }
+          }
         }
         placeholders.delete(chatId)
         accumulatedText.delete(chatId)

--- a/adapters/telegram/index.ts
+++ b/adapters/telegram/index.ts
@@ -8,20 +8,16 @@
 import { Bot, InlineKeyboard, type Context } from 'grammy'
 import * as path from 'node:path'
 import { WsBridge, type ServerMessage } from '../common/ws-bridge.js'
-import { MessageBuffer } from '../common/message-buffer.js'
 import { MessageDedup } from '../common/message-dedup.js'
 import { enqueue } from '../common/chat-queue.js'
-import { loadConfig } from '../common/config.js'
+import { getConfiguredWorkDir, loadConfig } from '../common/config.js'
 import {
   formatImStatus,
   formatPermissionRequest,
   splitMessage,
 } from '../common/format.js'
 import {
-  buildTelegramThinkingUpdate,
   formatTelegramOutboundText,
-  formatTelegramStreamingText,
-  planTelegramStreamingUpdate,
 } from './format.js'
 import {
   formatPermissionDecisionStatus,
@@ -31,7 +27,7 @@ import {
   type PermissionDecision,
 } from '../common/permission.js'
 import { SessionStore } from '../common/session-store.js'
-import { createAdapterClient } from '../common/adapter-client.js'
+import { AdapterHttpClient } from '../common/http-client.js'
 import { restoreStoredSessionBinding } from '../common/session-recovery.js'
 import { isAllowedUser, tryPair } from '../common/pairing.js'
 import { TelegramMediaService } from './media.js'
@@ -43,9 +39,9 @@ import type { PendingUpload } from '../common/attachment/attachment-types.js'
 import { sendSafeOutboundImage } from '../common/attachment/outbound-image.js'
 import { syncTelegramBotCommands } from './menu.js'
 import { createTelegramRuntimeCommandController, registerAuthorizedTelegramCommand, registerTelegramExtendedCommands, shouldProcessTelegramMessage, tryHandleTelegramSelectionCallback } from './commands.js'
+import { TelegramTypingController } from './typing.js'
 
 const TELEGRAM_TEXT_LIMIT = 4000 // leave margin below 4096
-const TELEGRAM_STREAMING_TEXT_LIMIT = TELEGRAM_TEXT_LIMIT - 2 // reserve room for cursor
 
 // ---------- init ----------
 
@@ -59,20 +55,17 @@ const bot = new Bot(config.telegram.botToken)
 const bridge = new WsBridge(config.serverUrl, 'tg')
 const dedup = new MessageDedup()
 const sessionStore = new SessionStore()
-const { httpClient, defaultWorkDir } = createAdapterClient(config, config.telegram)
+const defaultWorkDir = getConfiguredWorkDir(config, config.telegram)
+const httpClient = new AdapterHttpClient(config.serverUrl, { allowedProjectRoots: [defaultWorkDir] })
 const attachmentStore = new AttachmentStore()
 const media = new TelegramMediaService(bot, attachmentStore)
+const typingController = new TelegramTypingController((chatId, action) => bot.api.sendChatAction(chatId, action))
 attachmentStore.gc().catch((err) => {
   console.warn('[Telegram] AttachmentStore.gc failed:', err instanceof Error ? err.message : err)
 })
 
-// Track placeholder messages for streaming updates
-const placeholders = new Map<string, { chatId: string; messageId: number }>()
-// Track accumulated text per chat for streaming
+// Track pending reply text per chat (delivered as one message on completion)
 const accumulatedText = new Map<string, string>()
-const accumulatedThinkingText = new Map<string, string>()
-// Message buffers per chat
-const buffers = new Map<string, MessageBuffer>()
 // Track chats waiting for project selection
 const pendingProjectSelection = new Map<string, boolean>()
 const runtimeStates = new Map<string, ChatRuntimeState>()
@@ -100,17 +93,6 @@ const commandController = createTelegramRuntimeCommandController({ botApi: bot.a
 
 // ---------- helpers ----------
 
-function getBuffer(chatId: string): MessageBuffer {
-  let buf = buffers.get(chatId)
-  if (!buf) {
-    buf = new MessageBuffer(async (text, isComplete) => {
-      await flushToTelegram(chatId, text, isComplete)
-    })
-    buffers.set(chatId, buf)
-  }
-  return buf
-}
-
 function getRuntimeState(chatId: string): ChatRuntimeState {
   let state = runtimeStates.get(chatId)
   if (!state) {
@@ -121,10 +103,8 @@ function getRuntimeState(chatId: string): ChatRuntimeState {
 }
 
 function clearTransientChatState(chatId: string): void {
-  placeholders.delete(chatId)
   accumulatedText.delete(chatId)
-  accumulatedThinkingText.delete(chatId)
-  buffers.get(chatId)?.reset()
+  typingController.stop(chatId)
   const runtime = getRuntimeState(chatId)
   runtime.state = 'idle'
   runtime.verb = undefined
@@ -215,109 +195,45 @@ async function buildStatusText(chatId: string): Promise<string> {
   })
 }
 
-async function flushToTelegram(chatId: string, newText: string, isComplete: boolean): Promise<void> {
-  const numericChatId = Number(chatId)
-  const prev = accumulatedText.get(chatId) ?? ''
-
-  const placeholder = placeholders.get(chatId)
-
-  if (placeholder) {
-    if (isComplete) {
-      const fullText = prev + newText
-      accumulatedText.set(chatId, fullText)
-      const chunks = splitMessage(formatTelegramOutboundText(fullText), TELEGRAM_TEXT_LIMIT)
-      try {
-        await bot.api.editMessageText(numericChatId, placeholder.messageId, chunks[0]!)
-      } catch (err) {
-        console.error('[Telegram] editMessageText (complete) failed, sending as new message:', err instanceof Error ? err.message : err)
-        try {
-          await bot.api.sendMessage(numericChatId, chunks[0]!)
-        } catch (sendErr) {
-          console.error('[Telegram] fallback sendMessage (complete chunk 0) failed:', sendErr instanceof Error ? sendErr.message : sendErr)
-        }
-      }
-      for (let i = 1; i < chunks.length; i++) {
-        try {
-          await bot.api.sendMessage(numericChatId, chunks[i]!)
-        } catch (err) {
-          console.error('[Telegram] sendMessage (complete chunk) failed:', err instanceof Error ? err.message : err)
-        }
-      }
-    } else {
-      const { sealedChunks, activeChunk } = planTelegramStreamingUpdate(
-        prev,
-        newText,
-        TELEGRAM_STREAMING_TEXT_LIMIT,
-      )
-      accumulatedText.set(chatId, activeChunk)
-      const firstSealedChunk = sealedChunks.shift()
-      if (firstSealedChunk) {
-        const firstSealedFormattedChunks = splitMessage(
-          formatTelegramOutboundText(firstSealedChunk),
-          TELEGRAM_TEXT_LIMIT,
-        )
-        try {
-          await bot.api.editMessageText(numericChatId, placeholder.messageId, firstSealedFormattedChunks[0]!)
-        } catch (err) {
-          console.error('[Telegram] editMessageText (streaming) failed, sending as new message:', err instanceof Error ? err.message : err)
-          try {
-            await bot.api.sendMessage(numericChatId, firstSealedFormattedChunks[0]!)
-          } catch (sendErr) {
-            console.error('[Telegram] fallback sendMessage (streaming chunk 0) failed:', sendErr instanceof Error ? sendErr.message : sendErr)
-          }
-        }
-        for (let i = 1; i < firstSealedFormattedChunks.length; i++) {
-          try {
-            await bot.api.sendMessage(numericChatId, firstSealedFormattedChunks[i]!)
-          } catch (err) {
-            console.error('[Telegram] sendMessage (streaming sealed) failed:', err instanceof Error ? err.message : err)
-          }
-        }
-        for (const chunk of sealedChunks) {
-          const formattedChunks = splitMessage(formatTelegramOutboundText(chunk), TELEGRAM_TEXT_LIMIT)
-          for (const formattedChunk of formattedChunks) {
-            try {
-              await bot.api.sendMessage(numericChatId, formattedChunk)
-            } catch (err) {
-              console.error('[Telegram] sendMessage (streaming sealed) failed:', err instanceof Error ? err.message : err)
-            }
-          }
-        }
-        try {
-          const sent = await bot.api.sendMessage(numericChatId, formatTelegramStreamingText(activeChunk))
-          placeholders.set(chatId, { chatId, messageId: sent.message_id })
-        } catch (err) {
-          console.error('[Telegram] sendMessage (streaming active) failed:', err instanceof Error ? err.message : err)
-        }
-      } else {
-        try {
-          await bot.api.editMessageText(numericChatId, placeholder.messageId, formatTelegramStreamingText(activeChunk))
-        } catch (err) {
-          console.error('[Telegram] editMessageText (streaming single) failed, sending as new message:', err instanceof Error ? err.message : err)
-          try {
-            const sent = await bot.api.sendMessage(numericChatId, formatTelegramStreamingText(activeChunk))
-            placeholders.set(chatId, { chatId, messageId: sent.message_id })
-          } catch (sendErr) {
-            console.error('[Telegram] fallback sendMessage (streaming single) failed:', sendErr instanceof Error ? sendErr.message : sendErr)
-          }
-        }
-      }
+function getFloodRetryAfter(err: unknown): number | null {
+  if (err && typeof err === 'object') {
+    const e = err as { error_code?: number; parameters?: { retry_after?: number } }
+    if (e.error_code === 429 && typeof e.parameters?.retry_after === 'number') {
+      return e.parameters.retry_after
     }
-  } else if (isComplete && (prev + newText).trim()) {
-    const fullText = prev + newText
-    accumulatedText.set(chatId, fullText)
-    const chunks = splitMessage(formatTelegramOutboundText(fullText), TELEGRAM_TEXT_LIMIT)
-    for (const chunk of chunks) {
-      await bot.api.sendMessage(numericChatId, chunk)
-    }
-  } else {
-    accumulatedText.set(chatId, prev + newText)
   }
+  return null
+}
 
-  if (isComplete) {
-    placeholders.delete(chatId)
-    accumulatedText.delete(chatId)
-    buffers.get(chatId)?.reset()
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** Send with Telegram flood-control (429) backoff so replies always arrive. */
+async function sendWithFloodRetry<T>(fn: () => Promise<T>, maxAttempts = 4): Promise<T> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      const retryAfter = getFloodRetryAfter(err)
+      if (retryAfter != null && retryAfter > 0 && attempt < maxAttempts - 1) {
+        console.warn(`[Telegram] 429 flood control, waiting ${retryAfter}s then retrying`)
+        await sleep(Math.min(retryAfter, 120) * 1000)
+        continue
+      }
+      throw err
+    }
+  }
+}
+
+/** Send a reply message, splitting at the Telegram length limit. */
+async function sendTextToTelegram(chatId: string, text: string): Promise<void> {
+  const trimmed = text.trim()
+  if (!trimmed) return
+  const numericChatId = Number(chatId)
+  const chunks = splitMessage(formatTelegramOutboundText(trimmed), TELEGRAM_TEXT_LIMIT)
+  for (const chunk of chunks) {
+    await sendWithFloodRetry(() => bot.api.sendMessage(numericChatId, chunk))
   }
 }
 
@@ -339,11 +255,7 @@ async function ensureSession(chatId: string): Promise<boolean> {
 async function createSessionForChat(chatId: string, workDir: string): Promise<boolean> {
   const numericChatId = Number(chatId)
   try {
-    // Always tear down any stale WS connection before creating a new session.
-    // Without this, bridge.connectSession() below would short-circuit when an
-    // old OPEN connection still exists, leaving messages routed to the old session.
     bridge.resetSession(chatId)
-
     const sessionId = await httpClient.createSession(workDir)
     sessionStore.set(chatId, sessionId, workDir)
     bridge.connectSession(chatId, sessionId)
@@ -385,9 +297,6 @@ async function showProjectPicker(chatId: string): Promise<void> {
 
 // ---------- outbound media dispatch ----------
 
-/** Upload a PendingUpload found in streaming output and send it via
- *  bot.api.sendPhoto as an independent message. Runs fire-and-forget
- *  from the stream handler so streaming text isn't blocked. */
 async function dispatchOutboundMedia(chatId: string, pending: PendingUpload): Promise<void> {
   const numericChatId = Number(chatId)
   try {
@@ -405,7 +314,6 @@ async function dispatchOutboundMedia(chatId: string, pending: PendingUpload): Pr
 
 async function handleServerMessage(chatId: string, msg: ServerMessage): Promise<void> {
   const numericChatId = Number(chatId)
-  const buf = getBuffer(chatId)
   const runtime = getRuntimeState(chatId)
 
   switch (msg.type) {
@@ -415,49 +323,30 @@ async function handleServerMessage(chatId: string, msg: ServerMessage): Promise<
     case 'status':
       runtime.state = msg.state
       runtime.verb = typeof msg.verb === 'string' ? msg.verb : undefined
-      if (msg.state === 'thinking' && !placeholders.has(chatId)) {
-        const sent = await bot.api.sendMessage(numericChatId, '💭 思考中...')
-        placeholders.set(chatId, { chatId, messageId: sent.message_id })
-        accumulatedText.set(chatId, '')
-        accumulatedThinkingText.set(chatId, '')
+      if (msg.state === 'thinking') {
+        typingController.start(chatId)
+      } else if (msg.state === 'idle') {
+        typingController.stop(chatId)
       }
       break
 
     case 'content_start':
       if (msg.blockType === 'text') {
-        accumulatedThinkingText.delete(chatId)
-        if (!placeholders.has(chatId)) {
-          const sent = await bot.api.sendMessage(numericChatId, '▍')
-          placeholders.set(chatId, { chatId, messageId: sent.message_id })
-          accumulatedText.set(chatId, '')
-        }
+        typingController.start(chatId)
       } else if (msg.blockType === 'tool_use') {
-        // Finalize current text placeholder before tool calls,
-        // so text after tools gets a fresh message
-        await buf.complete()
-        // If placeholder still exists (buffer was already empty), clean up directly
-        if (placeholders.has(chatId)) {
-          const text = accumulatedText.get(chatId)
-          if (text?.trim()) {
-            try {
-              await bot.api.editMessageText(
-                numericChatId,
-                placeholders.get(chatId)!.messageId,
-                formatTelegramOutboundText(text),
-              )
-            } catch { /* ignore */ }
-          }
-          placeholders.delete(chatId)
-          accumulatedText.delete(chatId)
-          buffers.get(chatId)?.reset()
+        const pending = accumulatedText.get(chatId) ?? ''
+        accumulatedText.set(chatId, '')
+        if (pending.trim()) {
+          await sendTextToTelegram(chatId, pending).catch((err) => {
+            console.error('[Telegram] send failed:', err instanceof Error ? err.message : String(err))
+          })
         }
       }
       break
 
     case 'content_delta':
       if (msg.text) {
-        accumulatedThinkingText.delete(chatId)
-        buf.append(msg.text)
+        accumulatedText.set(chatId, (accumulatedText.get(chatId) ?? '') + msg.text)
         const newUploads = getTgWatcher(chatId).feed(msg.text)
         for (const pending of newUploads) {
           void dispatchOutboundMedia(chatId, pending)
@@ -466,29 +355,13 @@ async function handleServerMessage(chatId: string, msg: ServerMessage): Promise<
       break
 
     case 'thinking':
-      if (placeholders.has(chatId)) {
-        const update = buildTelegramThinkingUpdate(
-          accumulatedThinkingText.get(chatId) ?? '',
-          msg.text,
-        )
-        accumulatedThinkingText.set(chatId, update.fullText)
-        try {
-          await bot.api.editMessageText(
-            numericChatId,
-            placeholders.get(chatId)!.messageId,
-            update.messageText,
-          )
-        } catch { /* ignore */ }
-      }
+      // Live feedback is handled by the typing indicator; thinking text is noise.
       break
 
     case 'tool_use_complete':
-      // Tool details are noise for IM users; visible in Desktop if needed.
       break
 
     case 'tool_result':
-      // Tool errors are handled internally by the AI (retries etc.)
-      // No need to notify the user for every failed attempt.
       break
 
     case 'permission_request': {
@@ -507,46 +380,25 @@ async function handleServerMessage(chatId: string, msg: ServerMessage): Promise<
       break
     }
 
-    case 'message_complete':
+    case 'message_complete': {
       runtime.state = 'idle'
       runtime.verb = undefined
-      await buf.complete()
-      // Ensure placeholder is always cleaned up even if buffer was already empty
-      if (placeholders.has(chatId)) {
-        const text = accumulatedText.get(chatId)
-        if (text?.trim()) {
-          const chunks = splitMessage(formatTelegramOutboundText(text), TELEGRAM_TEXT_LIMIT)
-          try {
-            await bot.api.editMessageText(numericChatId, placeholders.get(chatId)!.messageId, chunks[0]!)
-          } catch (err) {
-            console.error('[Telegram] editMessageText (message_complete) failed, sending as new message:', err instanceof Error ? err.message : err)
-            try {
-              await bot.api.sendMessage(numericChatId, chunks[0]!)
-            } catch (sendErr) {
-              console.error('[Telegram] fallback sendMessage (message_complete chunk 0) failed:', sendErr instanceof Error ? sendErr.message : sendErr)
-            }
-          }
-          for (let i = 1; i < chunks.length; i++) {
-            try {
-              await bot.api.sendMessage(numericChatId, chunks[i]!)
-            } catch (err) {
-              console.error('[Telegram] sendMessage (message_complete chunk) failed:', err instanceof Error ? err.message : err)
-            }
-          }
-        }
-        placeholders.delete(chatId)
-        accumulatedText.delete(chatId)
-        accumulatedThinkingText.delete(chatId)
-        buffers.get(chatId)?.reset()
+      typingController.stop(chatId)
+      const finalText = accumulatedText.get(chatId) ?? ''
+      accumulatedText.delete(chatId)
+      if (finalText.trim()) {
+        await sendTextToTelegram(chatId, finalText).catch((err) => {
+          console.error('[Telegram] send failed:', err instanceof Error ? err.message : String(err))
+        })
       }
       break
+    }
 
     case 'error':
       runtime.state = 'idle'
       runtime.verb = undefined
-      accumulatedThinkingText.delete(chatId)
-      // Auto-recover from stale thinking block signatures by creating a fresh session.
-      // This happens when the API key or provider changed since the session was created.
+      typingController.stop(chatId)
+      accumulatedText.delete(chatId)
       if (msg.message && /Invalid.*signature.*thinking/i.test(msg.message)) {
         const stored = sessionStore.get(chatId)
         const workDir = stored?.workDir || defaultWorkDir
@@ -584,18 +436,13 @@ async function handleServerMessage(chatId: string, msg: ServerMessage): Promise<
 
 registerTelegramExtendedCommands(bot, commandController)
 
-/** Reset session state and start a new session for chatId.
- *  If `query` is provided, match a project by index or name;
- *  otherwise use the configured/default work directory. */
 async function startNewSession(chatId: string, query?: string): Promise<void> {
   const numericChatId = Number(chatId)
 
   bridge.resetSession(chatId)
   sessionStore.delete(chatId)
-  placeholders.delete(chatId)
   accumulatedText.delete(chatId)
-  buffers.get(chatId)?.reset()
-  buffers.delete(chatId)
+  typingController.stop(chatId)
   pendingProjectSelection.delete(chatId)
   commandController.clearPendingSelections(chatId)
   pendingPermissions.delete(chatId)
@@ -691,9 +538,6 @@ for (const command of ['allow', 'always', 'allow-always', 'deny'] as const) {
   })
 }
 
-/** Shared per-user-message pipeline: dedup, pairing check, project-pick
- *  routing, enqueue, ensureSession, sendUserMessage with attachments.
- *  Caller has already extracted text and attachments from the context. */
 async function routeUserMessage(
   ctx: Context,
   text: string,
@@ -737,13 +581,12 @@ async function routeUserMessage(
     const sent = bridge.sendUserMessage(chatId, effective, attachments.length ? attachments : undefined)
     if (!sent) {
       await bot.api.sendMessage(Number(chatId), '⚠️ 消息发送失败，连接可能已断开。请发送 /new 重新开始。')
+    } else {
+      typingController.start(chatId)
     }
   })
 }
 
-/** Scan ctx.message for photo/document/video/audio/voice, download
- *  each via TelegramMediaService, apply size/mime limits, and produce
- *  a ready-to-send AttachmentRef[] plus any rejection hints. */
 async function collectAttachmentsFromCtx(
   ctx: Context,
 ): Promise<{ attachments: AttachmentRef[]; rejections: string[] }> {
@@ -786,7 +629,6 @@ async function collectAttachmentsFromCtx(
     }
   }
 
-  // Photos: grammY exposes an array of sizes, largest last.
   if (msg.photo && msg.photo.length > 0) {
     const largest = msg.photo[msg.photo.length - 1]!
     await runOne(largest.file_id, `photo-${largest.file_unique_id}.jpg`, 'image/jpeg')
@@ -856,6 +698,7 @@ process.on('SIGINT', () => {
   console.log('[Telegram] Shutting down...')
   bot.stop()
   bridge.destroy()
+  typingController.destroy()
   dedup.destroy()
   process.exit(0)
 })

--- a/adapters/telegram/typing.ts
+++ b/adapters/telegram/typing.ts
@@ -1,0 +1,43 @@
+/**
+ * Telegram typing indicator controller.
+ *
+ * Telegram's "typing…" bubble expires after ~5 seconds, so it must be
+ * re-sent while the desktop session is actively thinking/streaming. We send
+ * one immediately on start and keep a keepalive timer until the turn ends.
+ */
+
+type SendChatAction = (chatId: number | string, action: 'typing') => Promise<unknown>
+
+export class TelegramTypingController {
+  private readonly active = new Map<string, ReturnType<typeof setInterval>>()
+
+  constructor(
+    private readonly sendChatAction: SendChatAction,
+    private readonly keepaliveIntervalMs = 4000,
+  ) {}
+
+  start(chatId: string): void {
+    if (this.active.has(chatId)) return
+    const numericChatId = Number(chatId)
+    void this.sendChatAction(numericChatId, 'typing').catch(() => {})
+    const timer = setInterval(() => {
+      void this.sendChatAction(numericChatId, 'typing').catch(() => {})
+    }, this.keepaliveIntervalMs)
+    this.active.set(chatId, timer)
+  }
+
+  stop(chatId: string): void {
+    const timer = this.active.get(chatId)
+    if (timer) {
+      clearInterval(timer)
+      this.active.delete(chatId)
+    }
+  }
+
+  destroy(): void {
+    for (const timer of this.active.values()) {
+      clearInterval(timer)
+    }
+    this.active.clear()
+  }
+}


### PR DESCRIPTION
## 问题描述

Telegram Bot 回复被截断，只收到部分回复，但桌面端显示完整回复。

## 根因分析

### Bug 1：单个 try-catch 包裹多个 API 调用

`flushToTelegram` 中 streaming 和 message_complete 分支的 `editMessageText` 和多个 `sendMessage` 调用被包裹在同一个 `try { ... } catch { /* ignore */ }` 中。当 `editMessageText` 失败时（如 Telegram API 限流、消息过长等），后续所有 `sendMessage` 调用被跳过，导致部分内容或全部内容丢失。

### Bug 2：streaming 文本长度未预留光标空间

`planTelegramStreamingUpdate` 检查 `formatTelegramOutboundText(fullText).length <= limit`，但实际发送时 `formatTelegramStreamingText` 会追加 `▍`（2 字符），导致实际长度超出 Telegram 4096 限制，API 调用失败。

### Bug 3：多字节字符边界截断

`splitMessage` 回退到 `splitAt = limit` 时可能在 UTF-16 代理对中间截断（如 emoji），产生损坏的文本。

## 修改内容

| 文件 | 修改 |
| --- | --- |
| `adapters/telegram/index.ts` | 拆分 try-catch 到每个独立 API 调用；editMessageText 失败时用 sendMessage 回退；添加错误日志 |
| `adapters/telegram/format.ts` | `planTelegramStreamingUpdate` 在 limit 中预留 ▍ 的 2 字节空间 |
| `adapters/common/format.ts` | `splitMessage` 增加 UTF-16 代理对边界保护 |

## 影响范围

- IM Adapter (Telegram)
- 不影响其他 adapter (WeChat/Feishu/DingTalk/WhatsApp)

## 测试说明

- 本地无 bun/node 运行时，无法运行 `bun run check:adapters`
- 已做静态代码审查确认修改正确
- 建议维护者在合并前运行 `bun run check:adapters`

## 剩余风险

- 当前环境无 bun 运行时，未能执行 adapter 单元测试
- 如 Telegram API 持续限流，fallback sendMessage 也可能失败（已添加错误日志便于排查）