### PR TITLE
fix(proxy): avoid duplicate /v1 in upstream OpenAI endpoint URL

### DIFF
--- a/src/server/__tests__/proxy-upstream-url.test.ts
+++ b/src/server/__tests__/proxy-upstream-url.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test'
+
+import { buildOpenAIEndpointUrl } from '../proxy/upstreamUrl.js'
+
+describe('buildOpenAIEndpointUrl', () => {
+  test('does not duplicate the v1 path when base URL already includes it', () => {
+    expect(buildOpenAIEndpointUrl('https://api.example.com/v1', 'chat/completions'))
+      .toBe('https://api.example.com/v1/chat/completions')
+    expect(buildOpenAIEndpointUrl('https://api.example.com/v1/', 'responses'))
+      .toBe('https://api.example.com/v1/responses')
+  })
+
+  test('adds the v1 path when base URL does not include it', () => {
+    expect(buildOpenAIEndpointUrl('https://api.example.com', 'chat/completions'))
+      .toBe('https://api.example.com/v1/chat/completions')
+    expect(buildOpenAIEndpointUrl('https://api.example.com/', 'responses'))
+      .toBe('https://api.example.com/v1/responses')
+  })
+
+  test('preserves a custom API path', () => {
+    expect(buildOpenAIEndpointUrl('https://gateway.example.com/openai/v1', 'chat/completions'))
+      .toBe('https://gateway.example.com/openai/v1/chat/completions')
+  })
+})

--- a/src/server/proxy/handler.ts
+++ b/src/server/proxy/handler.ts
@@ -25,6 +25,7 @@ import {
   type NetworkSettings,
 } from '../services/networkSettings.js'
 import { normalizeModelStringForAPI } from '../../utils/model/model.js'
+import { buildOpenAIEndpointUrl } from './upstreamUrl.js'
 import {
   createTraceCallId,
   createTraceBodySnapshot,
@@ -272,7 +273,7 @@ async function handleOpenaiChat(
     passThinkingToggle: deepSeekCompatible,
     imageContentMode: shouldUseTextOnlyOpenAIChatContent(baseUrl) ? 'text_only' : 'vision',
   })
-  const url = `${baseUrl}/v1/chat/completions`
+  const url = buildOpenAIEndpointUrl(baseUrl, 'chat/completions')
   const upstreamRequestHeaders = {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${apiKey}`,
@@ -441,7 +442,7 @@ async function handleOpenaiResponses(
   promptCacheKey?: string,
 ): Promise<Response> {
   const transformed = anthropicToOpenaiResponses(body, { cacheKey: promptCacheKey })
-  const url = `${baseUrl}/v1/responses`
+  const url = buildOpenAIEndpointUrl(baseUrl, 'responses')
   const upstreamRequestHeaders = {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${apiKey}`,

--- a/src/server/proxy/upstreamUrl.ts
+++ b/src/server/proxy/upstreamUrl.ts
@@ -1,0 +1,7 @@
+export function buildOpenAIEndpointUrl(baseUrl: string, endpoint: 'chat/completions' | 'responses'): string {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '')
+  const versionedBaseUrl = /\/v1$/i.test(normalizedBaseUrl)
+    ? normalizedBaseUrl
+    : `${normalizedBaseUrl}/v1`
+  return `${versionedBaseUrl}/${endpoint}`
+}

--- a/src/server/services/providerService.ts
+++ b/src/server/services/providerService.ts
@@ -48,6 +48,7 @@ import {
   type NetworkSettings,
 } from './networkSettings.js'
 import { normalizeModelStringForAPI } from '../../utils/model/model.js'
+import { buildOpenAIEndpointUrl } from '../proxy/upstreamUrl.js'
 import type {
   SavedProvider,
   ProvidersIndex,
@@ -733,10 +734,10 @@ export class ProviderService {
       let transformedBody: unknown
       if (format === 'openai_chat') {
         transformedBody = anthropicToOpenaiChat(anthropicReq)
-        upstreamUrl = `${base}/v1/chat/completions`
+        upstreamUrl = buildOpenAIEndpointUrl(base, 'chat/completions')
       } else {
         transformedBody = anthropicToOpenaiResponses(anthropicReq)
-        upstreamUrl = `${base}/v1/responses`
+        upstreamUrl = buildOpenAIEndpointUrl(base, 'responses')
       }
       const proxyOptions = getNetworkProxyFetchOptions(networkSettings, upstreamUrl)
 
@@ -794,14 +795,14 @@ function buildDirectTestRequest(
 
   if (format === 'openai_chat') {
     return {
-      url: `${base}/v1/chat/completions`,
+      url: buildOpenAIEndpointUrl(base, 'chat/completions'),
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
       body: { model: modelId, max_tokens: 16, stream: false, messages: [{ role: 'user', content: prompt }] },
     }
   }
   if (format === 'openai_responses') {
     return {
-      url: `${base}/v1/responses`,
+      url: buildOpenAIEndpointUrl(base, 'responses'),
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
       body: { model: modelId, max_output_tokens: 16, input: [{ type: 'message', role: 'user', content: prompt }] },
     }


### PR DESCRIPTION
## Summary
- 修复上游 OpenAI 兼容端点 URL 在拼接时重复出现 `/v1` 的问题（如 `.../v1/v1/...`）。
- 在 `upstreamUrl.ts` 增加去重/规范化逻辑，`handler.ts` 与 `providerService.ts` 调用处同步调整。
- 新增回归测试 `proxy-upstream-url.test.ts` 覆盖该场景。

## Test plan
- `bun test src/server/__tests__/proxy-upstream-url.test.ts`