### PR TITLE
修复 Anthropic→OpenAI chat 转换器丢弃 tool_result 图片，并按模型控制 text_only 门控

### DIFF
--- a/src/server/proxy/handler.ts
+++ b/src/server/proxy/handler.ts
@@ -270,7 +270,7 @@ async function handleOpenaiChat(
   const transformed = anthropicToOpenaiChat(body, {
     roundTripReasoningContent: deepSeekCompatible,
     passThinkingToggle: deepSeekCompatible,
-    imageContentMode: shouldUseTextOnlyOpenAIChatContent(baseUrl) ? 'text_only' : 'vision',
+    imageContentMode: shouldUseTextOnlyOpenAIChatContent(baseUrl, body.model) ? 'text_only' : 'vision',
   })
   const url = `${baseUrl}/v1/chat/completions`
   const upstreamRequestHeaders = {
@@ -427,8 +427,27 @@ function shouldUseDeepSeekReasoningCompat(baseUrl: string): boolean {
   )
 }
 
-function shouldUseTextOnlyOpenAIChatContent(baseUrl: string): boolean {
-  return shouldUseDeepSeekReasoningCompat(baseUrl)
+function shouldUseTextOnlyOpenAIChatContent(
+  baseUrl: string,
+  model?: string,
+): boolean {
+  // Classic DeepSeek API endpoints are text-only regardless of model.
+  if (/(^|[./-])deepseek([./-]|$)/i.test(baseUrl)) return true
+
+  // opencode.ai/zen is a multi-model gateway: some models see, some don't.
+  // Strip images only when the requested model isn't a known vision model, so a
+  // text-only model on the same gateway never receives image_url content.
+  if (/(^|[./-])opencode\.ai([:/]|$)/i.test(baseUrl)) {
+    return !isVisionModelName(model)
+  }
+
+  return false
+}
+
+function isVisionModelName(model?: string): boolean {
+  if (!model) return false
+  // Heuristic markers commonly used for vision-capable multimodal models.
+  return /(vision|visual|omni|4o|gemini|clip|\bvl\b)/i.test(model)
 }
 
 async function handleOpenaiResponses(

--- a/src/server/proxy/transform/anthropicToOpenaiChat.ts
+++ b/src/server/proxy/transform/anthropicToOpenaiChat.ts
@@ -173,16 +173,13 @@ function convertUserMessage(
         contentParts.push({ type: 'image_url', image_url: { url } })
       }
     } else if (block.type === 'tool_result') {
-      // tool_result → separate tool message
-      const resultContent = typeof block.content === 'string'
-        ? block.content
-        : Array.isArray(block.content)
-          ? block.content.filter((b): b is Extract<AnthropicContentBlock, { type: 'text' }> => b.type === 'text').map((b) => b.text).join('\n')
-          : ''
+      // tool_result → separate tool message. Preserve image blocks (e.g. the
+      // screenshot tool returns them here); only filtering for `text` would
+      // silently drop them. Mirrors anthropicToOpenaiResponses.
       output.push({
         role: 'tool',
         tool_call_id: block.tool_use_id,
-        content: resultContent,
+        content: convertToolResultContent(block.content, imageContentMode),
       })
     }
   }
@@ -203,6 +200,42 @@ function convertUserMessage(
         : contentParts,
     })
   }
+}
+
+function convertToolResultContent(
+  content: string | AnthropicContentBlock[],
+  imageContentMode: OpenAIChatImageContentMode,
+): string | OpenAIChatContentPart[] {
+  if (typeof content === 'string') return content
+
+  const textParts: string[] = []
+  const parts: OpenAIChatContentPart[] = []
+
+  for (const block of content) {
+    if (block.type === 'text') {
+      textParts.push(block.text)
+    } else if (block.type === 'image') {
+      if (imageContentMode === 'text_only') {
+        textParts.push(OMITTED_IMAGE_TEXT)
+      } else {
+        parts.push({
+          type: 'image_url',
+          image_url: { url: `data:${block.source.media_type};base64,${block.source.data}` },
+        })
+      }
+    }
+  }
+
+  // Plain text (or a single text block, or text_only images) stays a string so
+  // existing text-only tool results are byte-for-byte unchanged.
+  const text = textParts.join('\n')
+  if (text) {
+    parts.unshift({ type: 'text', text })
+  }
+
+  if (parts.length === 0) return ''
+  if (parts.length === 1 && parts[0].type === 'text') return parts[0].text
+  return parts
 }
 
 function convertAssistantMessage(


### PR DESCRIPTION
## 问题

Anthropic → OpenAI **Chat Completions** 转换器会丢弃 `tool_result` 块中的图片内容。

在 `anthropicToOpenaiChat.ts` 里，`tool_result` 分支只保留了 `text` 块：

```ts
block.content
  .filter((b): b is Extract<AnthropicContentBlock, { type: 'text' }> => b.type === 'text')
  .map((b) => b.text).join('\n')
```

`tool_result` 里的任何图片都被悄悄丢弃了。截图 / computer-use 工具会把捕获的图片放回 `tool_result`，于是截图结果到达上游时图片缺失，模型无图可看。

## 修复

`convertToolResultContent` 现在会保留 `tool_result` 里的 `text` 与 `image` 块：

- `text` 块用 `\n` 连接，纯文本 tool result 输出保持不变（字节级一致），
- `image` 块保留为 `image_url` 内容片段，
- 当 `imageContentMode = 'text_only'` 时替换为现有的 `[Image omitted: …]` 占位符。

## 范围说明

- 本 PR 只修 **chat** 路径（`openai_chat` provider，即本次报告的场景）。
- 当前源码里 **Responses** 路径（`anthropicToOpenaiResponses.ts`）已经保留 `tool_result` 中的 `text`/`image` 块（上游已修），无需改动。原始报告基于旧版 sidecar，其中 responses 路径也曾受影响。

## 次级改动：按模型而不是按 URL 来定 `text_only`

`shouldUseTextOnlyOpenAIChatContent` 原本等于 `shouldUseDeepSeekReasoningCompat`，所以**任何** `opencode.ai` 端点都被强制 `text_only`——把图片变成 `"[Image omitted]"`。

opencode.ai/zen 是**多模型网关**：有的模型能识图，有的不能。按 URL 门控是错误的——要么把能看图模型里的图片也剥掉，要么把 `image_url` 发给看不懂图的模型。

我在 `opencode.ai/zen/go`（模型 `deepseek-v4-flash-vision-exp`）上实测，它接受并正确描述了 `image_url` 内容（包括放在 **tool 角色消息**里）：

> "This image consists of a solid blue rectangle on the left, a white background area, and a green oval shape positioned on the right."

所以现在按**模型名**判断：只有看起来是视觉模型的才开 vision（`vision`/`visual`/`vl`/`4o`/`omni`/`gemini`/`clip`），该网关上的其他模型保持 `text_only`。经典 DeepSeek API 端点仍为 `text_only`。推理往返开关（`roundTripReasoningContent` / `passThinkingToggle`）单独覆盖 opencode.ai。

## 验证

- 用 bun 脚本跑了转换器（vision + text_only）。
- 向 `opencode.ai/zen/go` 实测了「assistant 带 tool_calls → tool 角色消息带 image_url」的完整序列，模型正确描述了图片。
- `tsc` 检查转换文件：改动的 `anthropicToOpenaiChat.ts` 无误；唯一报错是未改动的 `anthropicToOpenaiResponses.ts:86` 里已有的问题。

Fixes #1277.
