### PR TITLE
docs(readme): list WeCom, QQ and Slack IM platforms

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -131,7 +131,7 @@ See [environment variables](docs/en/cli/env.md) and [CLI setup](docs/en/cli/inde
 - **Computer Use**: let the agent take screenshots, click, type, and control desktop apps after authorization.
 - **Desktop pets**: Dada, Huhu, Bubu, and Huihui change what they do with the task at hand — or raise one of your own (off by default).
 - **H5 remote access**: scan a QR code to continue the session in your phone browser; locking the screen won't kill a running task.
-- **IM integration**: chat, switch projects, and approve actions through Telegram / Feishu / WeChat / DingTalk / WhatsApp.
+- **IM integration**: chat, switch projects, and approve actions through Telegram / Feishu / WeChat / DingTalk / WhatsApp / WeCom / QQ / Slack.
 - **Scheduled tasks and usage stats**: run planned tasks in their own sessions and track local token usage trends.
 
 ---
@@ -144,7 +144,7 @@ Full documentation site: <https://cchaha.ai>
 |------|------|
 | **Getting started** | [What this is](docs/en/start/index.md) · [Download and install](docs/en/start/install.md) · [Connect a model provider](docs/en/start/models.md) · [Your first session](docs/en/start/first-session.md) · [Troubleshooting](docs/en/start/troubleshooting.md) |
 | **Desktop features** | [Feature overview](docs/en/desktop/index.md) · [Computer Use](docs/en/desktop/computer-use.md) · [Desktop pets](docs/en/desktop/pets.md) · [Phone H5 and IM relay](docs/en/desktop/remote.md) |
-| **IM integrations** | [Overview and pairing](docs/en/im/index.md) · [Feishu](docs/en/im/feishu.md) · [Telegram](docs/en/im/telegram.md) · [WeChat](docs/en/im/wechat.md) · [DingTalk](docs/en/im/dingtalk.md) · [WhatsApp](docs/en/im/whatsapp.md) |
+| **IM integrations** | [Overview and pairing](docs/en/im/index.md) · [Feishu](docs/en/im/feishu.md) · [Telegram](docs/en/im/telegram.md) · [WeChat](docs/en/im/wechat.md) · [DingTalk](docs/en/im/dingtalk.md) · [WhatsApp](docs/en/im/whatsapp.md) · [WeCom](docs/en/im/wecom.md) · [QQ](docs/en/im/qq.md) · [Slack](docs/en/im/slack.md) |
 | **CLI** | [Install and run](docs/en/cli/index.md) · [Command reference](docs/en/cli/reference.md) · [Environment variables](docs/en/cli/env.md) |
 | **Internals** | [Desktop architecture](docs/en/internals/desktop.md) · [Multi-agent system](docs/en/internals/agent.md) · [Skills system](docs/en/internals/skills.md) · [Memory system](docs/en/internals/memory.md) · [Computer Use architecture](docs/en/internals/computer-use.md) · [Local server and API](docs/en/internals/server.md) · [Channel system](docs/en/internals/channel.md) · [Project structure](docs/en/internals/structure.md) · [Contributing and quality gates](docs/en/internals/contributing.md) |
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ cp .env.example .env
 - **Computer Use**：让 Agent 在授权后截图、点击、输入并控制桌面应用。
 - **桌面宠物**：搭搭、弧弧、补补、回回随任务状态换动作，也能自己做一只（默认关闭）。
 - **H5 远程访问**：扫码用手机浏览器接入当前会话，锁屏切后台都不打断正在跑的任务。
-- **IM 接入**：通过 Telegram / 飞书 / 微信 / 钉钉 / WhatsApp 远程对话、切换项目和审批权限。
+- **IM 接入**：通过 Telegram / 飞书 / 微信 / 钉钉 / WhatsApp / 企业微信 / QQ / Slack 远程对话、切换项目和审批权限。
 - **定时任务与用量统计**：创建计划任务在独立会话执行，并查看本机 Token 使用趋势。
 
 ---
@@ -144,7 +144,7 @@ cp .env.example .env
 |------|------|
 | **开始使用** | [这是什么](docs/start/index.md) · [下载与安装](docs/start/install.md) · [连接模型服务](docs/start/models.md) · [跑通第一条会话](docs/start/first-session.md) · [故障排查](docs/start/troubleshooting.md) |
 | **桌面端功能** | [功能总览](docs/desktop/index.md) · [Computer Use](docs/desktop/computer-use.md) · [桌面宠物](docs/desktop/pets.md) · [手机 H5 与 IM 接力](docs/desktop/remote.md) |
-| **IM 接入** | [总览与配对流程](docs/im/index.md) · [飞书](docs/im/feishu.md) · [Telegram](docs/im/telegram.md) · [微信](docs/im/wechat.md) · [钉钉](docs/im/dingtalk.md) · [WhatsApp](docs/im/whatsapp.md) |
+| **IM 接入** | [总览与配对流程](docs/im/index.md) · [飞书](docs/im/feishu.md) · [Telegram](docs/im/telegram.md) · [微信](docs/im/wechat.md) · [钉钉](docs/im/dingtalk.md) · [WhatsApp](docs/im/whatsapp.md) · [企业微信](docs/im/wecom.md) · [QQ](docs/im/qq.md) · [Slack](docs/im/slack.md) |
 | **命令行** | [安装与启动](docs/cli/index.md) · [命令参考](docs/cli/reference.md) · [环境变量](docs/cli/env.md) |
 | **深入原理** | [桌面端架构](docs/internals/desktop.md) · [多 Agent 系统](docs/internals/agent.md) · [Skills 系统](docs/internals/skills.md) · [记忆系统](docs/internals/memory.md) · [Computer Use 架构](docs/internals/computer-use.md) · [本地 Server 与 API](docs/internals/server.md) · [Channel 系统](docs/internals/channel.md) · [项目结构](docs/internals/structure.md) · [参与贡献与质量门禁](docs/internals/contributing.md) |
 


### PR DESCRIPTION
## Summary

Both READMEs advertise only five IM platforms — `Telegram / Feishu / WeChat / DingTalk / WhatsApp` — in the "Desktop Highlights" bullet and in the IM row of the "More Documentation" table. The desktop app has shipped **eight** adapters since v0.6.0; WeCom, QQ and Slack shipped with docs but were never added to the READMEs.

Evidence:

- `desktop/src/pages/AdapterSettings.tsx:11` — `type ImTab = 'telegram' | 'feishu' | 'wechat' | 'dingtalk' | 'whatsapp' | 'wecom' | 'qq' | 'slack'`
- Complete adapter implementations: `adapters/wecom/`, `adapters/qq/`, `adapters/slack/`
- Docs already exist: `docs/im/wecom.md`, `docs/im/qq.md`, `docs/im/slack.md` (and the `docs/en/im/` counterparts)
- `docs/im/index.md:28` — "八个平台的能力是同一套，差别在接入成本和审批体验。"
- `release-notes/v0.6.0.md:74` — "新增企业微信、QQ 和 Slack 适配器，接入统一的桌面会话流程"

Change: append `企业微信 / QQ / Slack` (EN: `WeCom / QQ / Slack`) to the IM highlight bullet, and append the three documentation links to the IM row in `README.md` and `README.en.md`. Docs only — no production code, no new dependencies, 2 files / +4 -4.

## Feature Quality Contract

- Changed surface: docs
- Tests added or updated: none. Documentation-only change; no executable production line was added or modified.
- Coverage evidence: not applicable. `scripts/pr/change-policy.ts` selects the coverage lane only for executable sources under `src/`, `desktop/src/`, `adapters/`, or `scripts/quality-gate/coverage*` — none of which this PR touches.
- E2E / live-model evidence: not run — docs-only change with no runtime behavior.
- Known risk / rollback: very low. Pure text edit across two README files; reverting the single commit restores the previous wording. The one judgement call is whether the highlight bullet should stay a curated short list — if so, I am happy to drop that hunk and keep only the documentation-table links.

## Verification

- [x] I ran the relevant local checks, or explained why they do not apply.
  - Docs lane, with the same commands CI uses for `check:docs`: `npm --prefix site run check:docs` → "Documentation check passed: 96 pages, 337 local links and images, 25 bilingual app screenshot pairs."; `npm --prefix site test` → 12 pass / 0 fail; `npm --prefix site run build` → succeeds, 96 documentation routes.
  - Scope selection, with the exact command CI runs: `bun run scripts/pr/change-policy.ts --files changed-files.txt --labels-file labels.txt --plan-only` → `Areas: docs`, `Checks: docs=true` (all other lanes false), not blocked. This confirms `README.md` / `README.en.md` are members of `docsExactPaths`, so only the docs lane is selected.
  - Verified every added relative link resolves on disk: `docs/im/{wecom,qq,slack}.md` and `docs/en/im/{wecom,qq,slack}.md`.
- [x] I added or updated same-area tests for every production behavior change. — No production behavior changed.
- [x] I ran the checks selected by `bun run check:impact`; if I claim PR-ready/full validation, I also ran `bun run verify`. — The single selected lane (`docs-checks`) was executed with the same commands CI uses, and scope selection was reproduced with `change-policy.ts --plan-only`. Full `bun run verify` was not run: this environment cannot install the repo's full Bun dependency graph; the docs lane is the only one this diff selects.
- [x] New or changed executable production lines meet the changed-line coverage threshold, or the blocker/maintainer override is documented. — No executable lines changed.
- [x] I attached or summarized the quality report path, JUnit/log artifact path, and pass/fail/skip counts. — `npm --prefix site run check` = `check:docs` + `node --test "src/**/*.test.js"`: 12 pass / 0 fail / 0 skipped. Diff is 2 files, +4/-4.
- [x] I ran deterministic E2E/contract checks for cross-boundary changes. Live-model evidence is attached when a trusted maintainer ran it, otherwise it is explicitly marked not run. — No cross-boundary change; live model: not run (untrusted fork / no provider).

## Risk

- [x] This PR does not touch CLI core paths, or it has maintainer approval for `allow-cli-core-change`.
- [x] Production code changes include matching tests, or have maintainer approval for `allow-missing-tests`. — No production code change.
- [x] Coverage baseline/threshold changes have maintainer approval for `allow-coverage-baseline-change`. — No baseline change.
- [x] Any quarantine-policy change has maintainer approval; deterministic provider/chat contract tests were not quarantined. — No quarantine change.
- [x] Provider/runtime changes are covered by offline mock/fixture contract tests; live smoke was run by a trusted maintainer or explicitly deferred. — No provider/runtime change.

Scope is deliberately narrow: 2 files, +4/-4, one topic. No bundled or unrelated edits.
