### PR TITLE
docs(im): add missing allowed project directories section to English overview

### DIFF
--- a/docs/en/im/index.md
+++ b/docs/en/im/index.md
@@ -74,6 +74,33 @@ Browsing preserves the current binding. `/cancel` exits selection; ordinary chat
 
 Telegram also keeps its `/resume` project and session button menu. The text commands above work on all platforms.
 
+## Allowed project directories decide which projects it can touch
+
+**Default Project** only decides where new sessions start — it is **not** the access boundary. The real boundary is **Allowed project directories**: the bot can only list, open, and start sessions in projects inside those directories, which constrains `/projects`, `/sessions`, and picking a project by name or absolute path.
+
+Leaving it empty means the default: your home directory (plus the default project, if it is outside home). Most people never need to change it. To narrow it to a few directories, add them to the list in Settings.
+
+The configuration lives in `~/.claude/adapters.json`, and each platform can be narrowed on its own:
+
+```json
+{
+  "allowedProjectRoots": ["~/work", "~/side"],
+  "whatsapp": { "allowedProjectRoots": ["~/work/sandbox"] }
+}
+```
+
+A per-platform setting **replaces** (does not add to) the global one: in the config above, WhatsApp can only touch `~/work/sandbox`, while every other platform gets `~/work` and `~/side`. The Settings UI edits the global copy, so once a platform is configured separately, changes made there no longer affect it.
+
+Running an adapter standalone (without the Desktop app) also accepts the `ADAPTER_ALLOWED_PROJECT_ROOTS` environment variable, with directories separated by the platform path delimiter (`:` on macOS / Linux, `;` on Windows). This environment variable outranks both file layers.
+
+A few boundary rules:
+
+- A directory must be an existing absolute path (`~` is expanded). Paths that do not exist are ignored and logged; if none resolve, the default is used rather than locking the bot out.
+- The default never inherits roots such as `/` or `/Users`. When the Desktop app is launched as a GUI, the sidecar's working directory is `/`, and taking that as the boundary is the same as having none.
+- If **Default Project** falls outside the allowed set, a new session starts in the first allowed directory and a line is logged — so `/new` does not fail when the two settings disagree.
+
+Pairing is still the first gate: an unpaired sender cannot issue commands at all, and this directory list is a second line of defense on top of it. Note that the home directory also contains sensitive paths like `~/.claude` and `~/.ssh`; for stronger isolation, narrow the list to specific project directories.
+
 ## Common commands
 
 Entry points differ slightly per platform — Feishu can expose commands as a bot menu — but these work everywhere:


### PR DESCRIPTION
## Summary

`docs/en/im/index.md` is missing an entire section that its Chinese counterpart `docs/im/index.md` has: **Allowed project directories**. The English reader is told about `/projects` and `/sessions` and about **Default Project**, but never learns that **Default Project** is *not* the access boundary — so the one knob that actually constrains which projects the bot can open is undocumented on the English site.

Evidence:

- `docs/im/index.md:77-102` — the section "允许访问的项目目录决定它能碰哪些项目" (includes the `allowedProjectRoots` JSON sample, the per-platform replace semantics, the `ADAPTER_ALLOWED_PROJECT_ROOTS` env var, and three boundary rules).
- `docs/en/im/index.md` — has no equivalent: the file jumps straight from "Find an old session from your phone" to "Common commands".
- Structure diff across the whole bilingual tree (headings / table rows / list items / code fences) singles this file out as the only real divergence: ZH `10 / 10 / 25 / 2` vs EN `9 / 10 / 22 / 0` before this change; every other EN/ZH pair is identical.
- Why it was dropped: the section was added to the Chinese file only, in `94168b3b` ("fix(adapters): restore IM /projects beyond the default project", #1191). That commit touched **zero** files under `docs/en/`, and `git log -S'allowedProjectRoots' -- docs/en/im/index.md` is empty — the English page never carried it.
- The behavior it documents is real in source: `adapters/common/config.ts:270-280` states the precedence verbatim — `ADAPTER_ALLOWED_PROJECT_ROOTS > platform-specific roots > global roots > default (home ∪ default work dir)` — and `adapters/common/config.ts:379` reads the env var.

Change: add the missing section to the English overview, translated from the Chinese source of truth and placed in the same position (between "Find an old session from your phone" and "Common commands"). UI labels reuse the wording already shipped in `desktop/src/i18n/locales/en.ts` (`settings.adapters.allowedRoots` → "Allowed project directories", `settings.adapters.defaultProject` → "Default Project"), so no new terminology is introduced. 1 file, +27, docs only — no production code, no new dependencies.

## Feature Quality Contract

- Changed surface: docs
- Tests added or updated: none. Documentation-only change; no executable production line was added or modified.
- Coverage evidence: not applicable. `scripts/pr/change-policy.ts` selects the coverage lane only for executable sources under `src/`, `desktop/src/`, `adapters/`, or `scripts/quality-gate/coverage*` — none of which this PR touches.
- E2E / live-model evidence: not run — docs-only change with no runtime behavior.
- Known risk / rollback: very low. One markdown file, additive only; reverting the single commit restores the previous text. The only judgement call is translation wording, which follows the existing English page and `en.ts` labels.

## Verification

- [x] I ran the relevant local checks, or explained why they do not apply.
  - Docs lane, with the same commands CI uses for `check:docs`: `npm --prefix site run check:docs` → "Documentation check passed: 96 pages, 337 local links and images, 25 bilingual app screenshot pairs."; `npm --prefix site test` → 12 pass / 0 fail; `npm --prefix site run build` → succeeds, 96 documentation routes.
  - Scope selection, with the exact command CI runs: `bun run scripts/pr/change-policy.ts --files changed-files.txt --labels-file labels.txt --plan-only` → `Areas: docs`, `Checks: docs=true` (all other lanes false), not blocked.
  - Re-ran the bilingual structure comparison after the edit: `docs/en/im/index.md` now matches the Chinese page exactly (10 headings / 10 table rows / 25 list items / 2 code fences / 142 lines), and it was the only pair flagged before.
- [x] I added or updated same-area tests for every production behavior change. — No production behavior changed.
- [x] I ran the checks selected by `bun run check:impact`; if I claim PR-ready/full validation, I also ran `bun run verify`. — The single selected lane (`docs-checks`) was executed with the same commands CI uses, and scope selection was reproduced with `change-policy.ts --plan-only`. Full `bun run verify` was not run: this environment cannot install the repo's full Bun dependency graph; the docs lane is the only one this diff selects.
- [x] New or changed executable production lines meet the changed-line coverage threshold, or the blocker/maintainer override is documented. — No executable lines changed.
- [x] I attached or summarized the quality report path, JUnit/log artifact path, and pass/fail/skip counts. — `check:docs` passed with 96 pages / 337 local links / 25 bilingual screenshot pairs; `node --test "src/**/*.test.js"`: 12 pass / 0 fail / 0 skipped. Diff is 1 file, +27.
- [x] I ran deterministic E2E/contract checks for cross-boundary changes. Live-model evidence is attached when a trusted maintainer ran it, otherwise it is explicitly marked not run. — No cross-boundary change; live model: not run (untrusted fork / no provider).

## Risk

- [x] This PR does not touch CLI core paths, or it has maintainer approval for `allow-cli-core-change`.
- [x] Production code changes include matching tests, or have maintainer approval for `allow-missing-tests`. — No production code change.
- [x] Coverage baseline/threshold changes have maintainer approval for `allow-coverage-baseline-change`. — No baseline change.
- [x] Any quarantine-policy change has maintainer approval; deterministic provider/chat contract tests were not quarantined. — No quarantine change.
- [x] Provider/runtime changes are covered by offline mock/fixture contract tests; live smoke was run by a trusted maintainer or explicitly deferred. — No provider/runtime change.

Scope is deliberately narrow: 1 file, +27, one topic, additive. No bundled or unrelated edits.
