### PR TITLE
docs(desktop): add missing allowed project directories entry to English remote page

### DIFF
--- a/docs/en/desktop/remote.md
+++ b/docs/en/desktop/remote.md
@@ -89,7 +89,8 @@ Paired users are listed below and can be unbound at any time; unbinding requires
 
 ### Other settings
 
-- **Default project** — the working directory for new IM sessions. Left empty, it uses your current user working directory.
+- **Default project** — the working directory for new IM sessions. Left empty, it uses your current user working directory. It's only a starting point — it doesn't restrict which projects the bot can reach.
+- **Allowed project directories** — the boundary for the bot: `/projects` only lists projects inside these directories. Left empty, it defaults to your home directory (plus the default project, if it is outside home).
 - **Streaming card mode** — updates the message content live, so it reads more like watching it type.
 - **Permission requests** — DingTalk can use an interactive card template ID for button-based approval. Without it, every platform falls back to the `/allow`, `/always`, and `/deny` text commands.
 


### PR DESCRIPTION
## Summary

`docs/en/desktop/remote.md` is missing content its Chinese counterpart has in the **Other settings** list: the **Allowed project directories** entry, and the caveat that **Default project** is *not* an access boundary. The English reader is told about **Default project** but never learns that the setting right below it is the one that actually constrains which projects the bot can open.

Evidence:

- `docs/desktop/remote.md:90-91` — two bullets, one of them the boundary statement (`它只是个起点，不限制机器人能访问哪些项目`).
- `docs/en/desktop/remote.md:92` before this change — a single `**Default project**` bullet with neither the caveat nor the following entry: the list jumps straight to `**Streaming card mode**`.
- Structure diff across the bilingual tree flags this pair and only this pair in the desktop group: list items ZH `9` vs EN `8`; headings (`10/10`), code fences (`7/7`) and table rows (`0/0`) were already equal.
- Why it was dropped: both bullets were added to the Chinese file in `94168b3b` ("fix(adapters): restore IM /projects beyond the default project", #1191). That commit touched **zero** files under `docs/en/` — `git show 94168b3b --name-only | grep -c docs/en` = `0` — and `git log -S'Allowed project directories' -- docs/en/desktop/remote.md` is empty, so the English page never carried it. The same commit caused the gap fixed in #1314 (`docs/en/im/index.md`); these are the only two docs the commit touched, and this is the second and last one.
- The behavior it documents is real in source: `adapters/common/config.ts:255-280` states the precedence and the rationale verbatim — `ADAPTER_ALLOWED_PROJECT_ROOTS > platform-specific roots > global roots > default (home ∪ default work dir)`, with `defaultWorkDir` "deliberately NOT derived from ... that field is documented as the *default* work dir for new IM sessions, not a boundary".

Change: add the missing bullet and the missing clause to `docs/en/desktop/remote.md`, translated from the Chinese source of truth and placed in the same position. UI labels reuse wording already shipped in `desktop/src/i18n/locales/en.ts` (`settings.adapters.allowedRoots` → "Allowed project directories" at `:912`, `settings.adapters.allowedRootsDefault` → "Default: your home directory (plus the default project, if it is outside home)" at `:915`), so no new terminology is introduced. 1 file, +2/-1, docs only — no production code, no new dependencies.

## Feature Quality Contract

- Changed surface: docs
- Tests added or updated: none. Documentation-only change; no executable production line was added or modified.
- Coverage evidence: not applicable. `scripts/pr/change-policy.ts` selects the coverage lane only for executable sources under `src/`, `desktop/src/`, `adapters/`, or `scripts/quality-gate/coverage*` — none of which this PR touches.
- E2E / live-model evidence: not run — docs-only change with no runtime behavior.
- Known risk / rollback: very low. One markdown file, additive only; reverting the single commit restores the previous text. The only judgement call is translation wording, which follows the existing English page and the `en.ts` labels.

## Verification

- [x] I ran the relevant local checks, or explained why they do not apply.
  - Docs lane, with the same commands CI uses for `check:docs`: `npm --prefix site run check:docs` → "Documentation check passed: 96 pages, 337 local links and images, 25 bilingual app screenshot pairs."; `npm --prefix site test` → 12 pass / 0 fail; `npm --prefix site run build` → succeeds, 96 documentation routes and 74 redirects.
  - Scope selection, with the exact command CI runs: `bun run scripts/pr/change-policy.ts --files changed-files.txt --labels-file labels.txt --plan-only` → `Areas: docs`, `Checks: docs=true` (all other lanes false), not blocked.
  - Re-ran the bilingual structure comparison after the edit: `docs/en/desktop/remote.md` now matches the Chinese page on headings, table rows, code fences and list items (`10 / 0 / 7 / 9`), and it was the only desktop pair flagged before.
- [x] I added or updated same-area tests for every production behavior change. — No production behavior changed.
- [x] I ran the checks selected by `bun run check:impact`; if I claim PR-ready/full validation, I also ran `bun run verify`. — The single selected lane (`docs-checks`) was executed with the same commands CI uses, and scope selection was reproduced with `change-policy.ts --plan-only`. Full `bun run verify` was not run: this environment cannot install the repo's full Bun dependency graph; the docs lane is the only one this diff selects.
- [x] New or changed executable production lines meet the changed-line coverage threshold, or the blocker/maintainer override is documented. — No executable lines changed.
- [x] I attached or summarized the quality report path, JUnit/log artifact path, and pass/fail/skip counts. — `check:docs` passed with 96 pages / 337 local links / 25 bilingual screenshot pairs; `node --test "src/**/*.test.js"`: 12 pass / 0 fail / 0 skipped. Diff is 1 file, +2/-1.
- [x] I ran deterministic E2E/contract checks for cross-boundary changes. Live-model evidence is attached when a trusted maintainer ran it, otherwise it is explicitly marked not run. — No cross-boundary change; live model: not run (untrusted fork / no provider).

## Risk

- [x] This PR does not touch CLI core paths, or it has maintainer approval for `allow-cli-core-change`.
- [x] Production code changes include matching tests, or have maintainer approval for `allow-missing-tests`. — No production code change.
- [x] Coverage baseline/threshold changes have maintainer approval for `allow-coverage-baseline-change`. — No baseline change.
- [x] Any quarantine-policy change has maintainer approval; deterministic provider/chat contract tests were not quarantined. — No quarantine change.
- [x] Provider/runtime changes are covered by offline mock/fixture contract tests; live smoke was run by a trusted maintainer or explicitly deferred. — No provider/runtime change.

Scope is deliberately narrow: 1 file, +2/-1, one topic, additive. No bundled or unrelated edits. Related but separate: the same page still says `five platforms` while `adapters/{wecom,qq,slack}` ship in both UI and `docs/im/`, which is a factual staleness affecting both languages — left out of this PR to keep it to translation parity.
